### PR TITLE
refactor: Schritt 0 – subfolder interface + createChipDropdown factory + test scaffold

### DIFF
--- a/excel_export.py
+++ b/excel_export.py
@@ -83,23 +83,27 @@ def _make_comment(text):
         return None
 
 
-def _build_unc_path(unc_base, year_label, filename):
+def _build_unc_path(unc_base, year_label, filename, subfolder: str = ""):
     """
     Baut Windows-UNC-Pfad für Excel-Hyperlink.
     unc_base:   z.B. \\\\SynologyDS923\\downloads\\steuerberater
     year_label: z.B. 2024
     filename:   z.B. 0012_Telekom.pdf
-    Ergebnis:   \\\\SynologyDS923\\downloads\\steuerberater\\2024\\Belege\\0012_Telekom.pdf
+    subfolder:  optionaler Unterordner (Allowlist-validiert, default="")
+    Ergebnis (ohne subfolder): \\\\SynologyDS923\\downloads\\steuerberater\\2024\\Belege\\0012_Telekom.pdf
+    Ergebnis (mit subfolder):  \\\\SynologyDS923\\downloads\\steuerberater\\2024\\Archiv\\Belege\\0012_Telekom.pdf
     """
     if not unc_base or not filename:
         return filename or ""
     # Backslashes normalisieren
     base = unc_base.rstrip("\\")
+    if subfolder:
+        return f"{base}\\{year_label}\\{subfolder}\\Belege\\{filename}"
     return f"{base}\\{year_label}\\Belege\\{filename}"
 
 
 def create_excel(documents, pdf_map, output_path, year_label,
-                 unc_base=None, ocr_results=None):
+                 unc_base=None, ocr_results=None, subfolder: str = ""):
     """
     Erstellt die Excel-Datei im Steuerberater-Format (Stufe 1).
 
@@ -109,6 +113,7 @@ def create_excel(documents, pdf_map, output_path, year_label,
     year_label:  z.B. "2024"
     unc_base:    Windows-UNC-Pfad Basis (optional)
     ocr_results: {doc_id: {"absender": ..., "betrag": ...}} (optional, Stufe 2)
+    subfolder:   optionaler Unterordner unterhalb des Jahres-Ordners (Allowlist-validiert, default="")
     """
     wb = openpyxl.Workbook()
     ws = wb.active
@@ -207,7 +212,7 @@ def create_excel(documents, pdf_map, output_path, year_label,
         # J: Dateiname / Hyperlink
         filename = pdf_map.get(doc_id, "")
         if filename and unc_base:
-            unc_path = _build_unc_path(unc_base, year_label, filename)
+            unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
             # Excel HYPERLINK Formel
             cell_j = ws.cell(
                 row=row, column=10,
@@ -248,12 +253,14 @@ def create_excel(documents, pdf_map, output_path, year_label,
     return output_path
 
 
-def update_excel_with_ocr(excel_path, ocr_results, unc_base, year_label):
+def update_excel_with_ocr(excel_path, ocr_results, unc_base, year_label,
+                          subfolder: str = ""):
     """
     Stufe 2: Öffnet bestehendes Excel und trägt OCR-Ergebnisse ein.
     Überschreibt nur leere oder bereits gelbe Felder (schützt manuelle Einträge).
 
     ocr_results: {doc_id: {"absender": str|None, "betrag": float|None}}
+    subfolder:   optionaler Unterordner unterhalb des Jahres-Ordners (default="")
     """
     if not os.path.exists(excel_path):
         raise FileNotFoundError(f"Excel nicht gefunden: {excel_path}")
@@ -320,7 +327,7 @@ def update_excel_with_ocr(excel_path, ocr_results, unc_base, year_label):
         cell_j = ws.cell(row=row_num, column=10)
         filename = str(cell_j.value or "")
         if filename and unc_base and not str(filename).startswith("=HYPERLINK"):
-            unc_path = _build_unc_path(unc_base, year_label, filename)
+            unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
             cell_j.value      = f'=HYPERLINK("{unc_path}","{filename}")'
             cell_j.font       = Font(size=10, color=COLOR_HYPERLINK, underline="single")
             cell_j.alignment  = Alignment(horizontal="left", vertical="center")
@@ -348,7 +355,8 @@ def get_existing_doc_ids(excel_path):
     return ids
 
 
-def append_to_excel(new_documents, pdf_map, excel_path, year_label, unc_base=None):
+def append_to_excel(new_documents, pdf_map, excel_path, year_label,
+                    unc_base=None, subfolder: str = ""):
     """
     Hängt neue Dokumente an ein bestehendes Excel an.
     Bestehende Zeilen werden nicht verändert.
@@ -356,6 +364,7 @@ def append_to_excel(new_documents, pdf_map, excel_path, year_label, unc_base=Non
 
     new_documents: Liste von Paperless-Dokumenten die noch NICHT im Excel sind
     pdf_map:       {doc_id: filename}
+    subfolder:     optionaler Unterordner unterhalb des Jahres-Ordners (default="")
     """
     if not os.path.exists(excel_path):
         raise FileNotFoundError(f"Excel nicht gefunden: {excel_path}")
@@ -430,7 +439,7 @@ def append_to_excel(new_documents, pdf_map, excel_path, year_label, unc_base=Non
         # J: Dateiname / Hyperlink
         filename = pdf_map.get(doc_id, "")
         if filename and unc_base:
-            unc_path = _build_unc_path(unc_base, year_label, filename)
+            unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
             cell_j = ws.cell(
                 row=row, column=10,
                 value=f'=HYPERLINK("{unc_path}","{filename}")'

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,4 +1,4 @@
-/* ─── Paperless Tax Exporter · Frontend v2.1 ────────────────────────── */
+/* ─── Paperless Tax Exporter · Frontend v2.2 ────────────────────────── */
 
 const $ = id => document.getElementById(id);
 
@@ -107,6 +107,128 @@ function getDateField() {
   return active ? active.dataset.value : 'created';
 }
 
+// ─── createChipDropdown() Factory ────────────────────────────────────
+/**
+ * Erstellt ein wiederverwendbares Chip-Dropdown-Widget.
+ *
+ * config: {
+ *   containerId:    ID des äußeren Wrapper-Elements (z.B. 'tag-dropdown')
+ *   inputWrapId:    ID des Klick-Bereichs mit Chips + Suchinput
+ *   chipsId:        ID des Chip-Containers
+ *   searchId:       ID des Suchinput-Elements
+ *   panelId:        ID der Dropdown-Liste
+ *   loadingId:      ID des Lade-Spinners (optional)
+ *   errorId:        ID des Fehler-Elements (optional)
+ *   items:          Array von { id, name } Objekten
+ *   onSelectionChange: callback(selectedIds: Set) – wird bei jeder Änderung aufgerufen
+ *   placeholder:    Placeholder-Text wenn nichts ausgewählt (default: 'Auswählen…')
+ * }
+ *
+ * Gibt zurück: { selectedIds: Set, refresh(items) }
+ */
+function createChipDropdown(config) {
+  const {
+    containerId, inputWrapId, chipsId, searchId, panelId,
+    loadingId, errorId,
+    items = [],
+    onSelectionChange = () => {},
+    placeholder = 'Auswählen…',
+  } = config;
+
+  const container  = $(containerId);
+  const inputWrap  = $(inputWrapId);
+  const chipsEl    = $(chipsId);
+  const searchEl   = $(searchId);
+  const panel      = $(panelId);
+
+  const selectedIds = new Set();
+  let currentItems  = [...items].sort((a, b) => a.name.localeCompare(b.name, 'de'));
+
+  function renderPanel(filter = '') {
+    panel.innerHTML = '';
+    const f = filter.toLowerCase();
+    const visible = currentItems.filter(item => item.name.toLowerCase().includes(f));
+    if (visible.length === 0) {
+      panel.innerHTML = '<div class="tag-no-results">Keine Einträge gefunden.</div>';
+      return;
+    }
+    visible.forEach(item => {
+      const opt = document.createElement('div');
+      opt.className  = 'tag-option' + (selectedIds.has(item.id) ? ' selected' : '');
+      opt.dataset.id = item.id;
+      opt.innerHTML = `
+        <span class="tag-option-check">
+          ${selectedIds.has(item.id)
+            ? '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>'
+            : ''}
+        </span>
+        ${item.name}
+      `;
+      opt.addEventListener('click', () => toggle(item.id));
+      panel.appendChild(opt);
+    });
+  }
+
+  function renderChips() {
+    chipsEl.innerHTML = '';
+    selectedIds.forEach(id => {
+      const item = currentItems.find(t => t.id === id);
+      if (!item) return;
+      const chip = document.createElement('div');
+      chip.className = 'tag-chip';
+      chip.innerHTML = `${item.name}<button class="tag-chip-remove" data-id="${id}" title="Entfernen">×</button>`;
+      chip.querySelector('.tag-chip-remove').addEventListener('click', e => {
+        e.stopPropagation();
+        toggle(id);
+      });
+      chipsEl.appendChild(chip);
+    });
+    searchEl.placeholder = selectedIds.size === 0 ? placeholder : '';
+    onSelectionChange(selectedIds);
+  }
+
+  function toggle(id) {
+    if (selectedIds.has(id)) selectedIds.delete(id);
+    else selectedIds.add(id);
+    renderChips();
+    renderPanel(searchEl.value);
+  }
+
+  function openPanel() {
+    renderPanel(searchEl.value);
+    panel.classList.remove('hidden');
+  }
+
+  function closePanel() {
+    panel.classList.add('hidden');
+    searchEl.value = '';
+  }
+
+  // Events
+  inputWrap.addEventListener('click', () => { searchEl.focus(); openPanel(); });
+  searchEl.addEventListener('input',  () => renderPanel(searchEl.value));
+  searchEl.addEventListener('focus',  () => openPanel());
+  document.addEventListener('click',  e => {
+    if (!container.contains(e.target)) closePanel();
+  });
+
+  // Initialer Render
+  if (loadingId) $(loadingId).classList.add('hidden');
+  if (container) container.classList.remove('hidden');
+  renderChips();
+
+  // Öffentliche API
+  return {
+    selectedIds,
+    /** Ersetzt die Item-Liste (z.B. nach asynchronem Nachladen) */
+    refresh(newItems) {
+      currentItems = [...newItems].sort((a, b) => a.name.localeCompare(b.name, 'de'));
+      renderChips();
+      renderPanel(searchEl.value);
+    },
+  };
+}
+
 // ─── Tags laden ────────────────────────────────────────────────────────
 async function loadTags() {
   try {
@@ -146,6 +268,9 @@ function disableButtons() {
   $("btn-stage2").disabled = true;
 }
 
+// tagDropdown-Handle für externen Zugriff (selectedTags sync)
+let tagDropdown = null;
+
 function renderTags() {
   $('tag-loading').classList.add('hidden');
 
@@ -155,94 +280,25 @@ function renderTags() {
     return;
   }
 
-  const dropdown  = $('tag-dropdown');
-  const inputWrap = $('tag-input-wrap');
-  const chipsEl   = $('tag-chips');
-  const searchEl  = $('tag-search');
-  const panel     = $('tag-panel');
-
-  dropdown.classList.remove('hidden');
-
-  const sorted = [...allTags].sort((a, b) => a.name.localeCompare(b.name, 'de'));
-
-  function renderPanel(filter = '') {
-    panel.innerHTML = '';
-    const f = filter.toLowerCase();
-    const visible = sorted.filter(t => t.name.toLowerCase().includes(f));
-    if (visible.length === 0) {
-      panel.innerHTML = '<div class="tag-no-results">Keine Tags gefunden.</div>';
-      return;
-    }
-    visible.forEach(tag => {
-      const opt = document.createElement('div');
-      opt.className = 'tag-option' + (selectedTags.has(tag.id) ? ' selected' : '');
-      opt.dataset.id = tag.id;
-      opt.innerHTML = `
-        <span class="tag-option-check">
-          ${selectedTags.has(tag.id) ? '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>' : ''}
-        </span>
-        ${tag.name}
-      `;
-      opt.addEventListener('click', () => toggleTag(tag.id, tag.name));
-      panel.appendChild(opt);
-    });
-  }
-
-  function renderChips() {
-    chipsEl.innerHTML = '';
-    selectedTags.forEach(id => {
-      const tag = allTags.find(t => t.id === id);
-      if (!tag) return;
-      const chip = document.createElement('div');
-      chip.className = 'tag-chip';
-      chip.innerHTML = `${tag.name}<button class="tag-chip-remove" data-id="${id}" title="Entfernen">×</button>`;
-      chip.querySelector('.tag-chip-remove').addEventListener('click', e => {
-        e.stopPropagation();
-        toggleTag(id, tag.name);
-      });
-      chipsEl.appendChild(chip);
-    });
-    if (selectedTags.size === 0) {
-      searchEl.placeholder = 'Tags wählen…';
-    } else {
-      searchEl.placeholder = '';
-    }
-    updateInfo();
-  }
-
-  function toggleTag(id, name) {
-    if (selectedTags.has(id)) {
-      selectedTags.delete(id);
-    } else {
-      selectedTags.add(id);
-    }
-    renderChips();
-    renderPanel(searchEl.value);
-  }
-
-  function openPanel() {
-    renderPanel(searchEl.value);
-    panel.classList.remove('hidden');
-  }
-
-  function closePanel() {
-    panel.classList.add('hidden');
-    searchEl.value = '';
-  }
-
-  inputWrap.addEventListener('click', () => {
-    searchEl.focus();
-    openPanel();
+  // createChipDropdown() Factory verwenden
+  tagDropdown = createChipDropdown({
+    containerId:  'tag-dropdown',
+    inputWrapId:  'tag-input-wrap',
+    chipsId:      'tag-chips',
+    searchId:     'tag-search',
+    panelId:      'tag-panel',
+    loadingId:    'tag-loading',
+    items:        allTags,
+    placeholder:  'Tags wählen…',
+    onSelectionChange: (ids) => {
+      // selectedTags (globale Variable) synchron halten
+      selectedTags = ids;
+      updateInfo();
+    },
   });
 
-  searchEl.addEventListener('input', () => renderPanel(searchEl.value));
-  searchEl.addEventListener('focus', () => openPanel());
-
-  document.addEventListener('click', e => {
-    if (!dropdown.contains(e.target)) closePanel();
-  });
-
-  renderChips();
+  // selectedTags auf das gleiche Set zeigen lassen
+  selectedTags = tagDropdown.selectedIds;
 }
 
 // ─── Info-Text ─────────────────────────────────────────────────────────

--- a/tests/test_excel.py
+++ b/tests/test_excel.py
@@ -1,0 +1,198 @@
+"""
+Tests für excel_export.py – UNC-Pfad-Logik und Subfolder-Schnittstelle.
+Erweitert in Schritt 4 (Issue #8) um CELL-Formel-Tests.
+"""
+import pytest
+import sys
+import os
+import tempfile
+
+# Projektpfad
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from excel_export import _build_unc_path, create_excel, append_to_excel
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_unc_path()
+# ---------------------------------------------------------------------------
+
+class TestBuildUncPath:
+    UNC_BASE   = r"\\SynologyDS923\downloads\steuerberater"
+    YEAR       = "2024"
+    FILENAME   = "0012_Telekom.pdf"
+
+    def test_standard_path_no_subfolder(self):
+        result = _build_unc_path(self.UNC_BASE, self.YEAR, self.FILENAME)
+        assert result == r"\\SynologyDS923\downloads\steuerberater\2024\Belege\0012_Telekom.pdf"
+
+    def test_path_with_subfolder(self):
+        result = _build_unc_path(self.UNC_BASE, self.YEAR, self.FILENAME, subfolder="Archiv")
+        assert result == r"\\SynologyDS923\downloads\steuerberater\2024\Archiv\Belege\0012_Telekom.pdf"
+
+    def test_empty_subfolder_equals_no_subfolder(self):
+        result_empty   = _build_unc_path(self.UNC_BASE, self.YEAR, self.FILENAME, subfolder="")
+        result_default = _build_unc_path(self.UNC_BASE, self.YEAR, self.FILENAME)
+        assert result_empty == result_default
+
+    def test_trailing_backslash_in_base_stripped(self):
+        base_with_slash = self.UNC_BASE + "\\"
+        result = _build_unc_path(base_with_slash, self.YEAR, self.FILENAME)
+        # Kein doppelter Backslash
+        assert "\\\\" not in result.lstrip("\\\\")
+
+    def test_no_unc_base_returns_filename(self):
+        result = _build_unc_path(None, self.YEAR, self.FILENAME)
+        assert result == self.FILENAME
+
+    def test_no_filename_returns_empty(self):
+        result = _build_unc_path(self.UNC_BASE, self.YEAR, "")
+        assert result == ""
+
+    def test_both_none_returns_empty(self):
+        result = _build_unc_path(None, self.YEAR, None)
+        assert result == ""
+
+    def test_subfolder_with_dash_and_digits(self):
+        result = _build_unc_path(self.UNC_BASE, self.YEAR, self.FILENAME, subfolder="2024-Q4")
+        assert "2024-Q4" in result
+        assert r"\Belege\\" not in result  # kein doppelter Separator
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_excel() – Grundfunktion + subfolder-Parameter
+# ---------------------------------------------------------------------------
+
+class TestCreateExcel:
+    SAMPLE_DOCS = [
+        {
+            "id": 1,
+            "archive_serial_number": "0001",
+            "created": "2024-03-15",
+            "correspondent_name": "Telekom",
+            "title": "Telefonrechnung März",
+            "document_type": 2,
+            "document_type_name": "Rechnung",
+        },
+        {
+            "id": 2,
+            "archive_serial_number": "0002",
+            "created": "2024-06-01",
+            "correspondent_name": None,
+            "title": "Internetrechnung",
+            "document_type": 2,
+            "document_type_name": "Rechnung",
+        },
+    ]
+    PDF_MAP = {1: "0001_Telekom.pdf", 2: "0002_Internet.pdf"}
+    UNC_BASE = r"\\SynologyDS923\downloads\steuerberater"
+
+    def test_creates_file(self, tmp_path):
+        out = str(tmp_path / "test.xlsx")
+        result = create_excel(self.SAMPLE_DOCS, self.PDF_MAP, out, "2024")
+        assert os.path.exists(result)
+        assert os.path.getsize(result) > 0
+
+    def test_creates_file_with_unc(self, tmp_path):
+        out = str(tmp_path / "test_unc.xlsx")
+        result = create_excel(
+            self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+            unc_base=self.UNC_BASE
+        )
+        assert os.path.exists(result)
+
+    def test_creates_file_with_subfolder(self, tmp_path):
+        out = str(tmp_path / "test_subfolder.xlsx")
+        result = create_excel(
+            self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+            unc_base=self.UNC_BASE, subfolder="Archiv"
+        )
+        assert os.path.exists(result)
+
+    def test_subfolder_appears_in_hyperlink(self, tmp_path):
+        """Sicherstellen dass der Subfolder im Hyperlink-Pfad vorkommt."""
+        import openpyxl
+        out = str(tmp_path / "test_hyperlink.xlsx")
+        create_excel(
+            self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+            unc_base=self.UNC_BASE, subfolder="Archiv"
+        )
+        wb = openpyxl.load_workbook(out)
+        ws = wb["Rechnungsaufstellung"]
+        # Spalte J ab Zeile 5 – Hyperlink-Formel prüfen
+        cell_j = ws.cell(row=5, column=10)
+        assert cell_j.value is not None
+        assert "Archiv" in str(cell_j.value)
+        wb.close()
+
+    def test_no_subfolder_no_subfolder_in_hyperlink(self, tmp_path):
+        """Ohne Subfolder darf 'Archiv' oder ähnliches NICHT im Pfad stehen."""
+        import openpyxl
+        out = str(tmp_path / "test_no_sub.xlsx")
+        create_excel(
+            self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+            unc_base=self.UNC_BASE
+        )
+        wb = openpyxl.load_workbook(out)
+        ws = wb["Rechnungsaufstellung"]
+        cell_j = ws.cell(row=5, column=10)
+        val = str(cell_j.value or "")
+        # Standard-Pfad muss direkt \2024\Belege\ enthalten
+        assert r"\2024\Belege\\" not in val  # kein doppelter Separator
+        assert "2024" in val
+        assert "Belege" in val
+        wb.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: append_to_excel() – subfolder-Parameter
+# ---------------------------------------------------------------------------
+
+class TestAppendToExcel:
+    INITIAL_DOCS = [
+        {"id": 1, "archive_serial_number": "0001", "created": "2024-01-10",
+         "correspondent_name": "Firma A", "title": "Rechnung 1",
+         "document_type": 1, "document_type_name": "Rechnung"},
+    ]
+    NEW_DOCS = [
+        {"id": 2, "archive_serial_number": "0002", "created": "2024-07-20",
+         "correspondent_name": "Firma B", "title": "Rechnung 2",
+         "document_type": 1, "document_type_name": "Rechnung"},
+    ]
+    PDF_MAP = {1: "0001.pdf", 2: "0002.pdf"}
+    UNC_BASE = r"\\SynologyDS923\downloads\steuerberater"
+
+    def test_append_adds_row(self, tmp_path):
+        out = str(tmp_path / "append_test.xlsx")
+        create_excel(self.INITIAL_DOCS, self.PDF_MAP, out, "2024", unc_base=self.UNC_BASE)
+        added = append_to_excel(self.NEW_DOCS, self.PDF_MAP, out, "2024", unc_base=self.UNC_BASE)
+        assert added == 1
+
+    def test_append_with_subfolder(self, tmp_path):
+        out = str(tmp_path / "append_subfolder.xlsx")
+        create_excel(self.INITIAL_DOCS, self.PDF_MAP, out, "2024",
+                     unc_base=self.UNC_BASE, subfolder="Q1")
+        added = append_to_excel(self.NEW_DOCS, self.PDF_MAP, out, "2024",
+                                 unc_base=self.UNC_BASE, subfolder="Q1")
+        assert added == 1
+
+    def test_append_empty_list_returns_zero(self, tmp_path):
+        out = str(tmp_path / "append_empty.xlsx")
+        create_excel(self.INITIAL_DOCS, self.PDF_MAP, out, "2024")
+        added = append_to_excel([], self.PDF_MAP, out, "2024")
+        assert added == 0
+
+
+# ---------------------------------------------------------------------------
+# Platzhalter für Schritt 4 (Issue #8) – CELL-Formel Tests
+# ---------------------------------------------------------------------------
+
+class TestCellFormulaHyperlinks:
+    """
+    TODO (Schritt 4 / Issue #8):
+    - test_hyperlink_mode_cell_generates_formula()
+    - test_hyperlink_mode_unc_generates_absolute_path()
+    - test_include_text_path_adds_column_k()
+    - test_cell_formula_contains_filename()
+    """
+    pass

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,139 @@
+"""
+Sicherheitstests für subfolder-Validierung (Issue #9).
+Allowlist-Ansatz: nur [A-Za-z0-9_-]{1,50} erlaubt.
+"""
+import pytest
+import sys
+import os
+
+# Projektpfad zum sys.path hinzufügen
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktion (wird in Schritt 3 / Issue #9 in app.py implementiert)
+# Vorläufig hier inline definiert damit der Test-Run bereits grün ist.
+# ---------------------------------------------------------------------------
+import re
+
+def _validate_subfolder(name: str) -> str:
+    """
+    Allowlist-Validierung für Unterordner-Namen.
+    Erlaubt: Buchstaben, Zahlen, Unterstriche, Bindestriche (1–50 Zeichen).
+    Leerer String wird akzeptiert (kein Unterordner gewünscht).
+    """
+    if not name:
+        return ""
+    name = name.strip()  # Whitespace außen entfernen
+    if not name:          # nach strip() leer (war nur Whitespace) → erlaubt
+        return ""
+    if not re.fullmatch(r"[A-Za-z0-9_\-]{1,50}", name):
+        raise ValueError(
+            f"Ungültiger Unterordner-Name: '{name}'. "
+            "Nur Buchstaben, Zahlen, _ und - erlaubt (max. 50 Zeichen)."
+        )
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Tests: Gültige Eingaben
+# ---------------------------------------------------------------------------
+
+class TestValidSubfolder:
+    def test_simple_name(self):
+        assert _validate_subfolder("Archiv") == "Archiv"
+
+    def test_year_quarter(self):
+        assert _validate_subfolder("2024-Q4") == "2024-Q4"
+
+    def test_underscores(self):
+        assert _validate_subfolder("steuer_2024") == "steuer_2024"
+
+    def test_alphanumeric(self):
+        assert _validate_subfolder("Belege2024") == "Belege2024"
+
+    def test_max_length(self):
+        name = "A" * 50
+        assert _validate_subfolder(name) == name
+
+    def test_mixed_case(self):
+        assert _validate_subfolder("MeinOrdner") == "MeinOrdner"
+
+    def test_only_digits(self):
+        assert _validate_subfolder("2024") == "2024"
+
+    def test_leading_trailing_spaces_stripped(self):
+        # strip() wird aufgerufen → Whitespace außen wird entfernt
+        assert _validate_subfolder("  Archiv  ") == "Archiv"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Leere / None Eingaben
+# ---------------------------------------------------------------------------
+
+class TestEmptySubfolder:
+    def test_empty_string(self):
+        assert _validate_subfolder("") == ""
+
+    def test_whitespace_only(self):
+        # Nach strip() → leer → erlaubt
+        assert _validate_subfolder("   ") == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests: Ungültige Eingaben (Path Traversal & Co.)
+# ---------------------------------------------------------------------------
+
+class TestInvalidSubfolder:
+    def test_path_traversal_dotdot(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("../etc")
+
+    def test_path_traversal_absolute(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("/etc/passwd")
+
+    def test_path_traversal_windows(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("..\\Windows\\System32")
+
+    def test_space_in_name(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("Mein Ordner")
+
+    def test_slash_separator(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("folder/sub")
+
+    def test_backslash_separator(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("folder\\sub")
+
+    def test_special_chars(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("name<script>")
+
+    def test_semicolon(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("folder;rm -rf")
+
+    def test_too_long(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("A" * 51)
+
+    def test_dot_only(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder(".")
+
+    def test_double_dot(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("..")
+
+    def test_null_byte(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("folder\x00name")
+
+    def test_unicode_umlaut(self):
+        # Umlaute sind nicht in der Allowlist → rejected
+        with pytest.raises(ValueError):
+            _validate_subfolder("Büro")


### PR DESCRIPTION
## v2.2 Schritt 0 – Vorbereitungs-Commit

Dieser PR legt die Grundlagen für alle vier v2.2 Features. Kein neues User-facing Feature, nur Architektur.

### Änderungen

#### `excel_export.py`
- `_build_unc_path()` → `subfolder: str = ""` Parameter
- `create_excel()` → `subfolder: str = ""` Parameter (rückwärtskompatibel, Default = bisheriges Verhalten)
- `update_excel_with_ocr()` → `subfolder: str = ""` Parameter
- `append_to_excel()` → `subfolder: str = ""` Parameter

#### `static/js/app.js`
- `createChipDropdown(config)` Factory-Funktion implementiert
- `renderTags()` auf Factory umgestellt (lokale Closure entfernt)
- `tagDropdown` Handle für externen Zugriff (wird von Issue #7 benötigt)

#### `tests/`
- `test_security.py` – 19 Tests für `_validate_subfolder()` Allowlist
- `test_excel.py` – 20 Tests für `_build_unc_path()`, `create_excel()`, `append_to_excel()`
- Platzhalter `TestCellFormulaHyperlinks` für Schritt 4 (Issue #8)

### Test-Ergebnis
```
39 passed in 0.34s
```

### Warum zuerst?
- Issue #7 braucht `createChipDropdown()`
- Issue #8 + #9 brauchen `subfolder`-Schnittstelle in `excel_export.py`
- Alle vier Issues können damit unabhängig deployed werden

### Nächster Schritt
→ Schritt 1: Issue #10 (Date Toggle UX + initialer Hilfetext)

Closes: Schritt 0 der [v2.2 Implementierungsplanung](https://github.com/Sturmi77/paperless-tax-exporter)