### PR TITLE
feat(issue-8): Portable CELL-Formel Hyperlinks + kopierbarer UNC-Pfad

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,15 @@ OUTPUT_DIR=/output
 # Windows UNC-Pfad für Excel-Hyperlinks (Backslashes verdoppeln)
 WINDOWS_UNC_PATH=\\SynologyDS923\downloads\steuerberater
 
+# ── Hyperlink-Modus (Issue #8) ──────────────────────────────────────
+# cell  = CELL("filename")-Formel – portabel, funktioniert nach Ordner-Verschiebung (empfohlen)
+# unc   = absoluter UNC-Pfad (bisheriges Verhalten, Fallback)
+HYPERLINK_MODE=cell
+
+# Spalte K mit kopierbarem UNC-Pfad (plain text für E-Mail/Chat)
+# true = Spalte K einblenden | false = Spalte K ausblenden (default)
+INCLUDE_TEXT_PATH=false
+
 # ── Image Tag ───────────────────────────────────────────────────────
 # latest = stabile Version, develop = Testversion
 IMAGE_TAG=latest

--- a/app.py
+++ b/app.py
@@ -1,6 +1,5 @@
 import os
 import re
-import re
 import io
 import json
 import requests
@@ -30,6 +29,12 @@ OUTPUT_DIR       = os.path.realpath(os.environ.get("OUTPUT_DIR", "/output"))
 OLLAMA_URL       = os.environ.get("OLLAMA_URL",       "http://192.168.178.115:11434")
 OLLAMA_MODEL     = os.environ.get("OLLAMA_MODEL",     "qwen2.5:3b")
 WINDOWS_UNC_PATH = os.environ.get("WINDOWS_UNC_PATH", r"\\SynologyDS923\downloads\steuerberater")
+# Issue #8: Hyperlink-Modus
+# "cell"  = CELL("filename")-Formel → portabel, funktioniert nach Ordner-Verschiebung
+# "unc"   = absoluter UNC-Pfad (bisheriges Verhalten, Fallback)
+HYPERLINK_MODE    = os.environ.get("HYPERLINK_MODE", "cell").lower()
+# Issue #8: Spalte K mit kopierbarem UNC-Pfad (plain text) einblenden
+INCLUDE_TEXT_PATH = os.environ.get("INCLUDE_TEXT_PATH", "false").lower() == "true"
 
 os.environ.setdefault("OLLAMA_URL",   OLLAMA_URL)
 os.environ.setdefault("OLLAMA_MODEL", OLLAMA_MODEL)
@@ -251,7 +256,9 @@ def run_stage0(date_from, date_to, tag_ids, tag_names, year_label, date_field="c
         _log("Erstelle Excel-Datei…")
         excel_filename = f"Rechnungsaufstellung_{year_label}.xlsx"
         excel_path     = os.path.join(export_folder, excel_filename)
-        create_excel(docs, {}, excel_path, year_label, unc_base=WINDOWS_UNC_PATH, subfolder=subfolder)
+        create_excel(docs, {}, excel_path, year_label, unc_base=WINDOWS_UNC_PATH,
+                      subfolder=subfolder, hyperlink_mode=HYPERLINK_MODE,
+                      include_text_path=INCLUDE_TEXT_PATH)
         _log(f"Excel gespeichert: {excel_filename}")
 
         with job_lock:
@@ -338,12 +345,16 @@ def run_stage1(date_from, date_to, tag_ids, tag_names, year_label,
         if append_mode and os.path.exists(excel_path):
             _log("Hänge neue Zeilen ans Excel an…")
             added = append_to_excel(docs_to_process, pdf_map, excel_path, year_label,
-                                    unc_base=WINDOWS_UNC_PATH, subfolder=subfolder)
+                                    unc_base=WINDOWS_UNC_PATH, subfolder=subfolder,
+                                    hyperlink_mode=HYPERLINK_MODE,
+                                    include_text_path=INCLUDE_TEXT_PATH)
             _log(f"Excel ergänzt: {added} neue Zeile(n) hinzugefügt.")
         else:
             _log("Erstelle Excel-Datei…")
             create_excel(docs_to_process, pdf_map, excel_path, year_label,
-                         unc_base=WINDOWS_UNC_PATH, subfolder=subfolder)
+                         unc_base=WINDOWS_UNC_PATH, subfolder=subfolder,
+                         hyperlink_mode=HYPERLINK_MODE,
+                         include_text_path=INCLUDE_TEXT_PATH)
             _log(f"Excel gespeichert: {excel_filename}")
 
         with job_lock:

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import os
 import re
+import re
 import io
 import json
 import requests
@@ -63,6 +64,25 @@ job_status = {
 }
 job_lock     = threading.Lock()
 cancel_event = threading.Event()   # Issue #2: Abbruch-Steuerung
+
+
+def _validate_subfolder(name: str) -> str:
+    """
+    Allowlist-Validierung für Unterordner-Namen (Issue #9).
+    Erlaubt: Buchstaben, Zahlen, Unterstriche, Bindestriche (1-50 Zeichen).
+    Leerer String → kein Unterordner (akzeptiert).
+    """
+    if not name:
+        return ""
+    name = name.strip()
+    if not name:
+        return ""
+    if not re.fullmatch(r"[A-Za-z0-9_\-]{1,50}", name):
+        raise ValueError(
+            f"Ungültiger Unterordner-Name: '{name}'. "
+            "Nur Buchstaben, Zahlen, _ und - erlaubt (max. 50 Zeichen)."
+        )
+    return name
 
 
 def _job_status_reset(stage):
@@ -191,7 +211,7 @@ def enrich_documents_with_correspondents(documents, correspondents):
 
 # ── Stufe 0: Nur Excel (Issue #1) ─────────────────────────────────────
 def run_stage0(date_from, date_to, tag_ids, tag_names, year_label, date_field="created",
-               document_type_ids=None):
+               document_type_ids=None, subfolder: str = ""):
     """Erstellt nur die Excel-Datei – kein PDF-Download, kein OCR."""
     global job_status
     try:
@@ -202,6 +222,8 @@ def run_stage0(date_from, date_to, tag_ids, tag_names, year_label, date_field="c
         _log(f"Datumsfeld: {'Scan-Datum' if date_field == 'added' else 'Belegdatum'}")
         if document_type_ids:
             _log(f"Dokumenttyp-Filter: {len(document_type_ids)} Typ(en)")
+        if subfolder:
+            _log(f"Unterordner: {subfolder}")
 
         _log("Lade Correspondents aus Paperless…")
         correspondents = get_all_correspondents()
@@ -229,7 +251,7 @@ def run_stage0(date_from, date_to, tag_ids, tag_names, year_label, date_field="c
         _log("Erstelle Excel-Datei…")
         excel_filename = f"Rechnungsaufstellung_{year_label}.xlsx"
         excel_path     = os.path.join(export_folder, excel_filename)
-        create_excel(docs, {}, excel_path, year_label, unc_base=WINDOWS_UNC_PATH)
+        create_excel(docs, {}, excel_path, year_label, unc_base=WINDOWS_UNC_PATH, subfolder=subfolder)
         _log(f"Excel gespeichert: {excel_filename}")
 
         with job_lock:
@@ -248,7 +270,8 @@ def run_stage0(date_from, date_to, tag_ids, tag_names, year_label, date_field="c
 
 # ── Stufe 1: Download + Excel ──────────────────────────────────────────
 def run_stage1(date_from, date_to, tag_ids, tag_names, year_label,
-              date_field="created", append_mode=False):
+               date_field="created", append_mode=False, document_type_ids=None,
+               subfolder: str = ""):
     global job_status
     try:
         _job_status_reset("stage1")
@@ -257,6 +280,8 @@ def run_stage1(date_from, date_to, tag_ids, tag_names, year_label,
         if tag_names:
             _log(f"Tags: {', '.join(tag_names)}")
         _log(f"Datumsfeld: {'Scan-Datum' if date_field == 'added' else 'Belegdatum'}")
+        if subfolder:
+            _log(f"Unterordner: {subfolder}")
 
         _log("Lade Correspondents aus Paperless…")
         correspondents = get_all_correspondents()
@@ -274,7 +299,11 @@ def run_stage1(date_from, date_to, tag_ids, tag_names, year_label,
             return
 
         export_folder  = os.path.join(OUTPUT_DIR, year_label)
-        pdf_folder     = os.path.join(export_folder, "Belege")
+        # Subfolder: <year>/<subfolder>/Belege/ wenn gesetzt, sonst <year>/Belege/
+        if subfolder:
+            pdf_folder = os.path.join(export_folder, subfolder, "Belege")
+        else:
+            pdf_folder = os.path.join(export_folder, "Belege")
         excel_filename = f"Rechnungsaufstellung_{year_label}.xlsx"
         excel_path     = os.path.join(export_folder, excel_filename)
         _assert_output_path(export_folder)
@@ -309,12 +338,12 @@ def run_stage1(date_from, date_to, tag_ids, tag_names, year_label,
         if append_mode and os.path.exists(excel_path):
             _log("Hänge neue Zeilen ans Excel an…")
             added = append_to_excel(docs_to_process, pdf_map, excel_path, year_label,
-                                    unc_base=WINDOWS_UNC_PATH)
+                                    unc_base=WINDOWS_UNC_PATH, subfolder=subfolder)
             _log(f"Excel ergänzt: {added} neue Zeile(n) hinzugefügt.")
         else:
             _log("Erstelle Excel-Datei…")
             create_excel(docs_to_process, pdf_map, excel_path, year_label,
-                         unc_base=WINDOWS_UNC_PATH)
+                         unc_base=WINDOWS_UNC_PATH, subfolder=subfolder)
             _log(f"Excel gespeichert: {excel_filename}")
 
         with job_lock:
@@ -336,7 +365,7 @@ def run_stage1(date_from, date_to, tag_ids, tag_names, year_label,
 # ── Stufe 2: OCR-Analyse via Ollama ───────────────────────────────────
 def run_stage2(excel_path, year_label, docs=None,
                date_from=None, date_to=None, tag_ids=None, date_field="created",
-               document_type_ids=None):
+               document_type_ids=None, subfolder: str = ""):
     """Issue #2: cancel_event wird nach jedem Dokument geprüft."""
     global job_status
     try:
@@ -417,7 +446,8 @@ def run_stage2(excel_path, year_label, docs=None,
 
         # Auch bei Abbruch: bisherige Ergebnisse sichern
         _log("Schreibe OCR-Ergebnisse ins Excel…")
-        updated   = update_excel_with_ocr(excel_path, ocr_results, WINDOWS_UNC_PATH, year_label)
+        updated   = update_excel_with_ocr(excel_path, ocr_results, WINDOWS_UNC_PATH, year_label,
+                                          subfolder=subfolder)
         cancelled = cancel_event.is_set()
         suffix    = " (abgebrochen)" if cancelled else ""
         _log(f"✓ Stufe 2 abgeschlossen. {updated} Felder aktualisiert.{suffix}")
@@ -535,6 +565,11 @@ def api_start():
     date_field          = data.get("date_field", "created")  # Issue #3
     append_mode         = data.get("append_mode", False)      # Issue #4: nur neue hinzufügen
     document_type_ids   = data.get("document_type_ids", []) or []  # Issue #7
+    subfolder_raw       = data.get("subfolder", "") or ""              # Issue #9
+    try:
+        subfolder = _validate_subfolder(subfolder_raw)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
 
     if not date_from or not date_to:
         return jsonify({"error": "Bitte Datumsbereich angeben."}), 400
@@ -546,7 +581,7 @@ def api_start():
         thread = threading.Thread(
             target=run_stage0,
             args=(date_from, date_to, tag_ids, tag_names, year_label, date_field),
-            kwargs={"document_type_ids": document_type_ids},
+            kwargs={"document_type_ids": document_type_ids, "subfolder": subfolder},
             daemon=True,
         )
     elif mode == "stage2":
@@ -563,13 +598,14 @@ def api_start():
         thread = threading.Thread(
             target=run_stage2,
             args=(excel_path, year_label, None, date_from, date_to, tag_ids, date_field),
-            kwargs={"document_type_ids": document_type_ids},
+            kwargs={"document_type_ids": document_type_ids, "subfolder": subfolder},
             daemon=True,
         )
     elif mode == "both":
         def run_both():
             run_stage1(date_from, date_to, tag_ids, tag_names, year_label, date_field,
-                       append_mode=append_mode, document_type_ids=document_type_ids)
+                       append_mode=append_mode, document_type_ids=document_type_ids,
+                       subfolder=subfolder)
             with job_lock:
                 ep  = job_status.get("excel_path")
                 err = job_status.get("error")
@@ -578,14 +614,15 @@ def api_start():
                     job_status.update({"running": True, "done": False})
                 cancel_event.clear()  # Sicherstellen dass kein alter Abbruch-State hängt
                 run_stage2(ep, year_label, None, date_from, date_to, tag_ids, date_field,
-                           document_type_ids=document_type_ids)
+                           document_type_ids=document_type_ids, subfolder=subfolder)
         thread = threading.Thread(target=run_both, daemon=True)
     else:
         # stage1
         thread = threading.Thread(
             target=run_stage1,
             args=(date_from, date_to, tag_ids, tag_names, year_label, date_field),
-            kwargs={"append_mode": append_mode, "document_type_ids": document_type_ids},
+            kwargs={"append_mode": append_mode, "document_type_ids": document_type_ids,
+                    "subfolder": subfolder},
             daemon=True,
         )
 

--- a/app.py
+++ b/app.py
@@ -134,7 +134,28 @@ def get_all_correspondents():
     return result
 
 
-def get_documents(date_from, date_to, tag_ids, date_field="created"):
+def get_all_document_types():
+    """Holt alle Document Types als Liste von {id, name}."""
+    types = []
+    url   = "/api/document_types/"
+    while url:
+        data = paperless_get(url)
+        for t in data.get("results", []):
+            types.append({"id": t["id"], "name": t["name"]})
+        next_url = data.get("next")
+        if next_url:
+            from urllib.parse import urlparse
+            parsed = urlparse(next_url)
+            url = parsed.path + ("?" + parsed.query if parsed.query else "")
+            if not url.startswith("/api/"):
+                url = None
+        else:
+            url = None
+    return types
+
+
+def get_documents(date_from, date_to, tag_ids, date_field="created",
+                  document_type_ids=None):
     """Issue #3: date_field = 'created' (Belegdatum) oder 'added' (Scan-Datum)."""
     documents = []
     params = {
@@ -144,6 +165,8 @@ def get_documents(date_from, date_to, tag_ids, date_field="created"):
     }
     if tag_ids:
         params["tags__id__all"] = ",".join(str(t) for t in tag_ids)
+    if document_type_ids:
+        params["document_type__id__in"] = ",".join(str(t) for t in document_type_ids)
 
     path = "/api/documents/"
     page = 1
@@ -167,7 +190,8 @@ def enrich_documents_with_correspondents(documents, correspondents):
 
 
 # ── Stufe 0: Nur Excel (Issue #1) ─────────────────────────────────────
-def run_stage0(date_from, date_to, tag_ids, tag_names, year_label, date_field="created"):
+def run_stage0(date_from, date_to, tag_ids, tag_names, year_label, date_field="created",
+               document_type_ids=None):
     """Erstellt nur die Excel-Datei – kein PDF-Download, kein OCR."""
     global job_status
     try:
@@ -176,13 +200,15 @@ def run_stage0(date_from, date_to, tag_ids, tag_names, year_label, date_field="c
         if tag_names:
             _log(f"Tags: {', '.join(tag_names)}")
         _log(f"Datumsfeld: {'Scan-Datum' if date_field == 'added' else 'Belegdatum'}")
+        if document_type_ids:
+            _log(f"Dokumenttyp-Filter: {len(document_type_ids)} Typ(en)")
 
         _log("Lade Correspondents aus Paperless…")
         correspondents = get_all_correspondents()
         _log(f"{len(correspondents)} Correspondents geladen.")
 
         _log("Lade Dokumentenliste…")
-        docs = get_documents(date_from, date_to, tag_ids, date_field)
+        docs = get_documents(date_from, date_to, tag_ids, date_field, document_type_ids)
         docs = enrich_documents_with_correspondents(docs, correspondents)
         _log(f"{len(docs)} Dokumente gefunden.")
 
@@ -237,7 +263,7 @@ def run_stage1(date_from, date_to, tag_ids, tag_names, year_label,
         _log(f"{len(correspondents)} Correspondents geladen.")
 
         _log("Lade Dokumentenliste…")
-        docs = get_documents(date_from, date_to, tag_ids, date_field)
+        docs = get_documents(date_from, date_to, tag_ids, date_field, document_type_ids)
         docs = enrich_documents_with_correspondents(docs, correspondents)
         _log(f"{len(docs)} Dokumente gefunden.")
 
@@ -309,7 +335,8 @@ def run_stage1(date_from, date_to, tag_ids, tag_names, year_label,
 
 # ── Stufe 2: OCR-Analyse via Ollama ───────────────────────────────────
 def run_stage2(excel_path, year_label, docs=None,
-               date_from=None, date_to=None, tag_ids=None, date_field="created"):
+               date_from=None, date_to=None, tag_ids=None, date_field="created",
+               document_type_ids=None):
     """Issue #2: cancel_event wird nach jedem Dokument geprüft."""
     global job_status
     try:
@@ -332,7 +359,7 @@ def run_stage2(excel_path, year_label, docs=None,
                     job_status.update({"done": True, "running": False,
                                        "cancelled": True, "cancellable": False})
                 return
-            docs = get_documents(date_from, date_to, tag_ids or [], date_field)
+            docs = get_documents(date_from, date_to, tag_ids or [], date_field, document_type_ids)
             docs = enrich_documents_with_correspondents(docs, correspondents)
             _log(f"{len(docs)} Dokumente geladen.")
             # Abbruch-Check nach Dokumente-Laden
@@ -421,6 +448,14 @@ def api_tags():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route("/api/document-types")
+def api_document_types():
+    try:
+        return jsonify({"document_types": get_all_document_types()})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
 @app.route("/api/status")
 def api_status():
     with job_lock:
@@ -490,15 +525,16 @@ def api_start():
         if job_status["running"]:
             return jsonify({"error": "Ein Job läuft bereits."}), 400
 
-    data        = request.json
-    date_from   = data.get("date_from")
-    date_to     = data.get("date_to")
-    tag_ids     = data.get("tag_ids", [])
-    tag_names   = data.get("tag_names", [])
-    year_label  = data.get("year_label", date_from[:4] if date_from else "export")
-    mode        = data.get("mode", "stage1")   # "stage0"|"stage1"|"stage2"|"both"
-    date_field  = data.get("date_field", "created")  # Issue #3
-    append_mode = data.get("append_mode", False)      # Issue #4: nur neue hinzufügen
+    data                = request.json
+    date_from           = data.get("date_from")
+    date_to             = data.get("date_to")
+    tag_ids             = data.get("tag_ids", [])
+    tag_names           = data.get("tag_names", [])
+    year_label          = data.get("year_label", date_from[:4] if date_from else "export")
+    mode                = data.get("mode", "stage1")   # "stage0"|"stage1"|"stage2"|"both"
+    date_field          = data.get("date_field", "created")  # Issue #3
+    append_mode         = data.get("append_mode", False)      # Issue #4: nur neue hinzufügen
+    document_type_ids   = data.get("document_type_ids", []) or []  # Issue #7
 
     if not date_from or not date_to:
         return jsonify({"error": "Bitte Datumsbereich angeben."}), 400
@@ -510,6 +546,7 @@ def api_start():
         thread = threading.Thread(
             target=run_stage0,
             args=(date_from, date_to, tag_ids, tag_names, year_label, date_field),
+            kwargs={"document_type_ids": document_type_ids},
             daemon=True,
         )
     elif mode == "stage2":
@@ -526,12 +563,13 @@ def api_start():
         thread = threading.Thread(
             target=run_stage2,
             args=(excel_path, year_label, None, date_from, date_to, tag_ids, date_field),
+            kwargs={"document_type_ids": document_type_ids},
             daemon=True,
         )
     elif mode == "both":
         def run_both():
             run_stage1(date_from, date_to, tag_ids, tag_names, year_label, date_field,
-                       append_mode=append_mode)
+                       append_mode=append_mode, document_type_ids=document_type_ids)
             with job_lock:
                 ep  = job_status.get("excel_path")
                 err = job_status.get("error")
@@ -539,14 +577,15 @@ def api_start():
                 with job_lock:
                     job_status.update({"running": True, "done": False})
                 cancel_event.clear()  # Sicherstellen dass kein alter Abbruch-State hängt
-                run_stage2(ep, year_label, None, date_from, date_to, tag_ids, date_field)
+                run_stage2(ep, year_label, None, date_from, date_to, tag_ids, date_field,
+                           document_type_ids=document_type_ids)
         thread = threading.Thread(target=run_both, daemon=True)
     else:
         # stage1
         thread = threading.Thread(
             target=run_stage1,
             args=(date_from, date_to, tag_ids, tag_names, year_label, date_field),
-            kwargs={"append_mode": append_mode},
+            kwargs={"append_mode": append_mode, "document_type_ids": document_type_ids},
             daemon=True,
         )
 

--- a/excel_export.py
+++ b/excel_export.py
@@ -49,6 +49,9 @@ COLUMNS = [
     ("Dateiname / Beleg",                   38.0,  "left"),
 ]
 
+# Optionale Spalte K (INCLUDE_TEXT_PATH=true)
+COLUMN_TEXT_PATH = ("Pfad (kopierbar)", 52.0, "left")
+
 DATE_FORMAT   = "DD.MM.YYYY"
 NUMBER_FORMAT = '#,##0.00 "€"'
 
@@ -102,18 +105,47 @@ def _build_unc_path(unc_base, year_label, filename, subfolder: str = ""):
     return f"{base}\\{year_label}\\Belege\\{filename}"
 
 
+def _build_cell_formula(subfolder_path: str) -> str:
+    r"""
+    Baut eine portable CELL("filename")-Hyperlink-Formel.
+
+    Die Formel berechnet den Hyperlink-Pfad dynamisch zur Laufzeit:
+      LEFT(CELL("filename"), FIND("[", CELL("filename"))-1) -> Ordnerpfad der Excel-Datei
+      & "Belege\\datei.pdf" -> relativer Unterordner + Dateiname
+
+    Dadurch friert Excel den Pfad NICHT ein - er bleibt nach Ordner-Verschiebung gueltig.
+
+    WICHTIG: Funktioniert nur wenn die Datei bereits gespeichert ist.
+    In einer neuen, ungespeicherten Datei gibt CELL("filename") "" zurueck.
+
+    subfolder_path: relativer Teilpfad nach dem Ordner der Excel-Datei
+                    z.B. "Belege\\0012_Telekom.pdf"
+    """
+    # Backslashes in der Formel müssen als \\ (4 Backslashes) codiert werden,
+    # damit Excel 2 Backslashes interpretiert → ein Backslash im Pfad
+    escaped = subfolder_path.replace("\\", "\\\\")
+    return (
+        f'=HYPERLINK('
+        f'LEFT(CELL("filename"),FIND("[",CELL("filename"))-1)&"{escaped}",'
+        f'"{subfolder_path.split(chr(92))[-1]}")'
+    )
+
+
 def create_excel(documents, pdf_map, output_path, year_label,
-                 unc_base=None, ocr_results=None, subfolder: str = ""):
+                 unc_base=None, ocr_results=None, subfolder: str = "",
+                 hyperlink_mode: str = "cell", include_text_path: bool = False):
     """
     Erstellt die Excel-Datei im Steuerberater-Format (Stufe 1).
 
-    documents:   Liste von Paperless-Dokumenten (API-Dicts)
-    pdf_map:     {doc_id: filename_in_pdf_folder}
-    output_path: Zielpfad der .xlsx-Datei
-    year_label:  z.B. "2024"
-    unc_base:    Windows-UNC-Pfad Basis (optional)
-    ocr_results: {doc_id: {"absender": ..., "betrag": ...}} (optional, Stufe 2)
-    subfolder:   optionaler Unterordner unterhalb des Jahres-Ordners (Allowlist-validiert, default="")
+    documents:         Liste von Paperless-Dokumenten (API-Dicts)
+    pdf_map:           {doc_id: filename_in_pdf_folder}
+    output_path:       Zielpfad der .xlsx-Datei
+    year_label:        z.B. "2024"
+    unc_base:          Windows-UNC-Pfad Basis (optional)
+    ocr_results:       {doc_id: {"absender": ..., "betrag": ...}} (optional, Stufe 2)
+    subfolder:         optionaler Unterordner (Allowlist-validiert, default="")
+    hyperlink_mode:    "cell" = CELL()-Formel (portabel); "unc" = absoluter UNC-Pfad (Issue #8)
+    include_text_path: True = Spalte K mit kopierbarem UNC-Pfad (Issue #8)
     """
     wb = openpyxl.Workbook()
     ws = wb.active
@@ -133,7 +165,10 @@ def create_excel(documents, pdf_map, output_path, year_label,
 
     # ── Zeile 4: Spaltenheader ───────────────────────────────────────────
     ws.row_dimensions[4].height = 36
-    for col_idx, (header, width, align) in enumerate(COLUMNS, start=1):
+    active_columns = list(COLUMNS)
+    if include_text_path:
+        active_columns.append(COLUMN_TEXT_PATH)
+    for col_idx, (header, width, align) in enumerate(active_columns, start=1):
         _header_cell(ws, 4, col_idx, header, align)
         ws.column_dimensions[get_column_letter(col_idx)].width = width
 
@@ -209,25 +244,43 @@ def create_excel(documents, pdf_map, output_path, year_label,
         _data_cell(ws, row, 9, None, align="right",
                    number_fmt=NUMBER_FORMAT, bg=COLOR_EMPTY_BG)
 
-        # J: Dateiname / Hyperlink
+        # J: Dateiname / Hyperlink (Issue #8: CELL-Formel oder UNC)
         filename = pdf_map.get(doc_id, "")
-        if filename and unc_base:
-            unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
-            # Excel HYPERLINK Formel
-            cell_j = ws.cell(
-                row=row, column=10,
-                value=f'=HYPERLINK("{unc_path}","{filename}")'
-            )
+        if filename:
+            if hyperlink_mode == "cell":
+                # CELL("filename")-Formel: portabel, funktioniert nach Ordner-Verschiebung
+                if subfolder:
+                    rel_path = f"{subfolder}\\Belege\\{filename}"
+                else:
+                    rel_path = f"Belege\\{filename}"
+                formula = _build_cell_formula(rel_path)
+            elif unc_base:
+                # Absoluter UNC-Pfad (Fallback / HYPERLINK_MODE=unc)
+                unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
+                formula  = f'=HYPERLINK("{unc_path}","{filename}")'
+            else:
+                formula = filename
+
+            cell_j = ws.cell(row=row, column=10, value=formula)
             cell_j.font      = Font(size=10, color=COLOR_HYPERLINK, underline="single")
             cell_j.alignment = Alignment(horizontal="left", vertical="center")
             cell_j.border    = BORDER
+
+            # Spalte K: kopierbarer UNC-Pfad (INCLUDE_TEXT_PATH=true)
+            if include_text_path and unc_base:
+                unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
+                cell_k = ws.cell(row=row, column=11, value=unc_path)
+                cell_k.font      = Font(size=9, color="666666")
+                cell_k.alignment = Alignment(horizontal="left", vertical="center")
+                cell_k.border    = BORDER
         else:
             _data_cell(ws, row, 10, filename, align="left")
 
     last_data_row = data_start_row + len(sorted_docs) - 1
 
     # ── Excel-Tabelle (Tabelle1) ──────────────────────────────────────────
-    table_ref = f"A4:{get_column_letter(len(COLUMNS))}{last_data_row}"
+    num_cols  = len(COLUMNS) + (1 if include_text_path else 0)
+    table_ref = f"A4:{get_column_letter(num_cols)}{last_data_row}"
     table = Table(displayName="Tabelle1", ref=table_ref)
     table.tableStyleInfo = TableStyleInfo(
         name="TableStyleLight1",
@@ -356,15 +409,18 @@ def get_existing_doc_ids(excel_path):
 
 
 def append_to_excel(new_documents, pdf_map, excel_path, year_label,
-                    unc_base=None, subfolder: str = ""):
+                    unc_base=None, subfolder: str = "",
+                    hyperlink_mode: str = "cell", include_text_path: bool = False):
     """
     Hängt neue Dokumente an ein bestehendes Excel an.
     Bestehende Zeilen werden nicht verändert.
     Gibt die Anzahl neu angehängter Zeilen zurück.
 
-    new_documents: Liste von Paperless-Dokumenten die noch NICHT im Excel sind
-    pdf_map:       {doc_id: filename}
-    subfolder:     optionaler Unterordner unterhalb des Jahres-Ordners (default="")
+    new_documents:     Liste von Paperless-Dokumenten die noch NICHT im Excel sind
+    pdf_map:           {doc_id: filename}
+    subfolder:         optionaler Unterordner (default="")
+    hyperlink_mode:    "cell" = CELL()-Formel; "unc" = absoluter UNC-Pfad (Issue #8)
+    include_text_path: Spalte K mit kopierbarem UNC-Pfad (Issue #8)
     """
     if not os.path.exists(excel_path):
         raise FileNotFoundError(f"Excel nicht gefunden: {excel_path}")
@@ -436,17 +492,32 @@ def append_to_excel(new_documents, pdf_map, excel_path, year_label,
         _data_cell(ws, row, 9, None, align="right",
                    number_fmt=NUMBER_FORMAT, bg=COLOR_EMPTY_BG)
 
-        # J: Dateiname / Hyperlink
+        # J: Dateiname / Hyperlink (Issue #8)
         filename = pdf_map.get(doc_id, "")
-        if filename and unc_base:
-            unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
-            cell_j = ws.cell(
-                row=row, column=10,
-                value=f'=HYPERLINK("{unc_path}","{filename}")'
-            )
+        if filename:
+            if hyperlink_mode == "cell":
+                if subfolder:
+                    rel_path = f"{subfolder}\\Belege\\{filename}"
+                else:
+                    rel_path = f"Belege\\{filename}"
+                formula = _build_cell_formula(rel_path)
+            elif unc_base:
+                unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
+                formula  = f'=HYPERLINK("{unc_path}","{filename}")'
+            else:
+                formula = filename
+
+            cell_j = ws.cell(row=row, column=10, value=formula)
             cell_j.font      = Font(size=10, color=COLOR_HYPERLINK, underline="single")
             cell_j.alignment = Alignment(horizontal="left", vertical="center")
             cell_j.border    = BORDER
+
+            if include_text_path and unc_base:
+                unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
+                cell_k = ws.cell(row=row, column=11, value=unc_path)
+                cell_k.font      = Font(size=9, color="666666")
+                cell_k.alignment = Alignment(horizontal="left", vertical="center")
+                cell_k.border    = BORDER
         else:
             _data_cell(ws, row, 10, filename, align="left")
 

--- a/excel_export.py
+++ b/excel_export.py
@@ -83,23 +83,27 @@ def _make_comment(text):
         return None
 
 
-def _build_unc_path(unc_base, year_label, filename):
+def _build_unc_path(unc_base, year_label, filename, subfolder: str = ""):
     """
     Baut Windows-UNC-Pfad für Excel-Hyperlink.
     unc_base:   z.B. \\\\SynologyDS923\\downloads\\steuerberater
     year_label: z.B. 2024
     filename:   z.B. 0012_Telekom.pdf
-    Ergebnis:   \\\\SynologyDS923\\downloads\\steuerberater\\2024\\Belege\\0012_Telekom.pdf
+    subfolder:  optionaler Unterordner (Allowlist-validiert, default="")
+    Ergebnis (ohne subfolder): \\\\SynologyDS923\\downloads\\steuerberater\\2024\\Belege\\0012_Telekom.pdf
+    Ergebnis (mit subfolder):  \\\\SynologyDS923\\downloads\\steuerberater\\2024\\Archiv\\Belege\\0012_Telekom.pdf
     """
     if not unc_base or not filename:
         return filename or ""
     # Backslashes normalisieren
     base = unc_base.rstrip("\\")
+    if subfolder:
+        return f"{base}\\{year_label}\\{subfolder}\\Belege\\{filename}"
     return f"{base}\\{year_label}\\Belege\\{filename}"
 
 
 def create_excel(documents, pdf_map, output_path, year_label,
-                 unc_base=None, ocr_results=None):
+                 unc_base=None, ocr_results=None, subfolder: str = ""):
     """
     Erstellt die Excel-Datei im Steuerberater-Format (Stufe 1).
 
@@ -109,6 +113,7 @@ def create_excel(documents, pdf_map, output_path, year_label,
     year_label:  z.B. "2024"
     unc_base:    Windows-UNC-Pfad Basis (optional)
     ocr_results: {doc_id: {"absender": ..., "betrag": ...}} (optional, Stufe 2)
+    subfolder:   optionaler Unterordner unterhalb des Jahres-Ordners (Allowlist-validiert, default="")
     """
     wb = openpyxl.Workbook()
     ws = wb.active
@@ -207,7 +212,7 @@ def create_excel(documents, pdf_map, output_path, year_label,
         # J: Dateiname / Hyperlink
         filename = pdf_map.get(doc_id, "")
         if filename and unc_base:
-            unc_path = _build_unc_path(unc_base, year_label, filename)
+            unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
             # Excel HYPERLINK Formel
             cell_j = ws.cell(
                 row=row, column=10,
@@ -248,12 +253,14 @@ def create_excel(documents, pdf_map, output_path, year_label,
     return output_path
 
 
-def update_excel_with_ocr(excel_path, ocr_results, unc_base, year_label):
+def update_excel_with_ocr(excel_path, ocr_results, unc_base, year_label,
+                          subfolder: str = ""):
     """
     Stufe 2: Öffnet bestehendes Excel und trägt OCR-Ergebnisse ein.
     Überschreibt nur leere oder bereits gelbe Felder (schützt manuelle Einträge).
 
     ocr_results: {doc_id: {"absender": str|None, "betrag": float|None}}
+    subfolder:   optionaler Unterordner unterhalb des Jahres-Ordners (default="")
     """
     if not os.path.exists(excel_path):
         raise FileNotFoundError(f"Excel nicht gefunden: {excel_path}")
@@ -320,7 +327,7 @@ def update_excel_with_ocr(excel_path, ocr_results, unc_base, year_label):
         cell_j = ws.cell(row=row_num, column=10)
         filename = str(cell_j.value or "")
         if filename and unc_base and not str(filename).startswith("=HYPERLINK"):
-            unc_path = _build_unc_path(unc_base, year_label, filename)
+            unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
             cell_j.value      = f'=HYPERLINK("{unc_path}","{filename}")'
             cell_j.font       = Font(size=10, color=COLOR_HYPERLINK, underline="single")
             cell_j.alignment  = Alignment(horizontal="left", vertical="center")
@@ -348,7 +355,8 @@ def get_existing_doc_ids(excel_path):
     return ids
 
 
-def append_to_excel(new_documents, pdf_map, excel_path, year_label, unc_base=None):
+def append_to_excel(new_documents, pdf_map, excel_path, year_label,
+                    unc_base=None, subfolder: str = ""):
     """
     Hängt neue Dokumente an ein bestehendes Excel an.
     Bestehende Zeilen werden nicht verändert.
@@ -356,6 +364,7 @@ def append_to_excel(new_documents, pdf_map, excel_path, year_label, unc_base=Non
 
     new_documents: Liste von Paperless-Dokumenten die noch NICHT im Excel sind
     pdf_map:       {doc_id: filename}
+    subfolder:     optionaler Unterordner unterhalb des Jahres-Ordners (default="")
     """
     if not os.path.exists(excel_path):
         raise FileNotFoundError(f"Excel nicht gefunden: {excel_path}")
@@ -430,7 +439,7 @@ def append_to_excel(new_documents, pdf_map, excel_path, year_label, unc_base=Non
         # J: Dateiname / Hyperlink
         filename = pdf_map.get(doc_id, "")
         if filename and unc_base:
-            unc_path = _build_unc_path(unc_base, year_label, filename)
+            unc_path = _build_unc_path(unc_base, year_label, filename, subfolder)
             cell_j = ws.cell(
                 row=row, column=10,
                 value=f'=HYPERLINK("{unc_path}","{filename}")'

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -379,31 +379,48 @@ body {
 }
 
 /* ─── Pill-Toggle (Datumsfeld) ─────────────────────────────────────── */
-.date-filter-toggle {
+.date-filter-row {
   display: flex;
-  gap: 6px;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
   margin-top: 8px;
 }
+.date-filter-toggle {
+  display: flex;
+  gap: 4px;
+  background: var(--border);
+  border-radius: 22px;
+  padding: 3px;
+}
+.date-toggle-hint {
+  font-size: .78rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+  flex: 1;
+  min-width: 180px;
+}
 .pill-btn {
-  padding: 4px 14px;
-  border-radius: 20px;
-  border: 1.5px solid var(--border);
-  background: var(--surface);
+  padding: 4px 16px;
+  border-radius: 18px;
+  border: none;
+  background: transparent;
   color: var(--text-muted);
   font-size: .8rem;
   font-family: var(--font);
+  font-weight: 400;
   cursor: pointer;
   transition: all .15s;
+  white-space: nowrap;
 }
 .pill-btn.pill-active {
-  background: var(--primary);
-  border-color: var(--primary);
-  color: #fff;
+  background: #fff;
+  color: var(--primary);
   font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0,0,0,.15);
 }
 .pill-btn:hover:not(.pill-active) {
-  border-color: var(--primary);
-  color: var(--primary);
+  color: var(--text);
 }
 
 /* ─── Chip-Dropdown ────────────────────────────────────────────────── */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -237,6 +237,32 @@ body {
   font-size: .88rem;
   font-family: 'Cascadia Code', 'Fira Mono', monospace;
 }
+/* ─── Unterordner-Eingabe (Issue #9) ──────────────────────────────── */
+.subfolder-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.output-path-base {
+  flex: 0 0 auto;
+  max-width: 60%;
+}
+.input-subfolder {
+  flex: 1;
+  min-width: 120px;
+  max-width: 200px;
+  padding: 5px 10px;
+  font-size: .85rem;
+}
+.subfolder-preview {
+  font-size: .78rem;
+  color: var(--primary);
+  margin-top: 4px;
+  font-weight: 500;
+}
+
+
 
 /* ─── Aktionen ─────────────────────────────────────────────────────── */
 .actions {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,4 +1,4 @@
-/* ─── Paperless Tax Exporter · Frontend v2.1 ────────────────────────── */
+/* ─── Paperless Tax Exporter · Frontend v2.2 ────────────────────────── */
 
 const $ = id => document.getElementById(id);
 
@@ -107,6 +107,128 @@ function getDateField() {
   return active ? active.dataset.value : 'created';
 }
 
+// ─── createChipDropdown() Factory ────────────────────────────────────
+/**
+ * Erstellt ein wiederverwendbares Chip-Dropdown-Widget.
+ *
+ * config: {
+ *   containerId:    ID des äußeren Wrapper-Elements (z.B. 'tag-dropdown')
+ *   inputWrapId:    ID des Klick-Bereichs mit Chips + Suchinput
+ *   chipsId:        ID des Chip-Containers
+ *   searchId:       ID des Suchinput-Elements
+ *   panelId:        ID der Dropdown-Liste
+ *   loadingId:      ID des Lade-Spinners (optional)
+ *   errorId:        ID des Fehler-Elements (optional)
+ *   items:          Array von { id, name } Objekten
+ *   onSelectionChange: callback(selectedIds: Set) – wird bei jeder Änderung aufgerufen
+ *   placeholder:    Placeholder-Text wenn nichts ausgewählt (default: 'Auswählen…')
+ * }
+ *
+ * Gibt zurück: { selectedIds: Set, refresh(items) }
+ */
+function createChipDropdown(config) {
+  const {
+    containerId, inputWrapId, chipsId, searchId, panelId,
+    loadingId, errorId,
+    items = [],
+    onSelectionChange = () => {},
+    placeholder = 'Auswählen…',
+  } = config;
+
+  const container  = $(containerId);
+  const inputWrap  = $(inputWrapId);
+  const chipsEl    = $(chipsId);
+  const searchEl   = $(searchId);
+  const panel      = $(panelId);
+
+  const selectedIds = new Set();
+  let currentItems  = [...items].sort((a, b) => a.name.localeCompare(b.name, 'de'));
+
+  function renderPanel(filter = '') {
+    panel.innerHTML = '';
+    const f = filter.toLowerCase();
+    const visible = currentItems.filter(item => item.name.toLowerCase().includes(f));
+    if (visible.length === 0) {
+      panel.innerHTML = '<div class="tag-no-results">Keine Einträge gefunden.</div>';
+      return;
+    }
+    visible.forEach(item => {
+      const opt = document.createElement('div');
+      opt.className  = 'tag-option' + (selectedIds.has(item.id) ? ' selected' : '');
+      opt.dataset.id = item.id;
+      opt.innerHTML = `
+        <span class="tag-option-check">
+          ${selectedIds.has(item.id)
+            ? '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>'
+            : ''}
+        </span>
+        ${item.name}
+      `;
+      opt.addEventListener('click', () => toggle(item.id));
+      panel.appendChild(opt);
+    });
+  }
+
+  function renderChips() {
+    chipsEl.innerHTML = '';
+    selectedIds.forEach(id => {
+      const item = currentItems.find(t => t.id === id);
+      if (!item) return;
+      const chip = document.createElement('div');
+      chip.className = 'tag-chip';
+      chip.innerHTML = `${item.name}<button class="tag-chip-remove" data-id="${id}" title="Entfernen">×</button>`;
+      chip.querySelector('.tag-chip-remove').addEventListener('click', e => {
+        e.stopPropagation();
+        toggle(id);
+      });
+      chipsEl.appendChild(chip);
+    });
+    searchEl.placeholder = selectedIds.size === 0 ? placeholder : '';
+    onSelectionChange(selectedIds);
+  }
+
+  function toggle(id) {
+    if (selectedIds.has(id)) selectedIds.delete(id);
+    else selectedIds.add(id);
+    renderChips();
+    renderPanel(searchEl.value);
+  }
+
+  function openPanel() {
+    renderPanel(searchEl.value);
+    panel.classList.remove('hidden');
+  }
+
+  function closePanel() {
+    panel.classList.add('hidden');
+    searchEl.value = '';
+  }
+
+  // Events
+  inputWrap.addEventListener('click', () => { searchEl.focus(); openPanel(); });
+  searchEl.addEventListener('input',  () => renderPanel(searchEl.value));
+  searchEl.addEventListener('focus',  () => openPanel());
+  document.addEventListener('click',  e => {
+    if (!container.contains(e.target)) closePanel();
+  });
+
+  // Initialer Render
+  if (loadingId) $(loadingId).classList.add('hidden');
+  if (container) container.classList.remove('hidden');
+  renderChips();
+
+  // Öffentliche API
+  return {
+    selectedIds,
+    /** Ersetzt die Item-Liste (z.B. nach asynchronem Nachladen) */
+    refresh(newItems) {
+      currentItems = [...newItems].sort((a, b) => a.name.localeCompare(b.name, 'de'));
+      renderChips();
+      renderPanel(searchEl.value);
+    },
+  };
+}
+
 // ─── Tags laden ────────────────────────────────────────────────────────
 async function loadTags() {
   try {
@@ -146,6 +268,9 @@ function disableButtons() {
   $("btn-stage2").disabled = true;
 }
 
+// tagDropdown-Handle für externen Zugriff (selectedTags sync)
+let tagDropdown = null;
+
 function renderTags() {
   $('tag-loading').classList.add('hidden');
 
@@ -155,94 +280,25 @@ function renderTags() {
     return;
   }
 
-  const dropdown  = $('tag-dropdown');
-  const inputWrap = $('tag-input-wrap');
-  const chipsEl   = $('tag-chips');
-  const searchEl  = $('tag-search');
-  const panel     = $('tag-panel');
-
-  dropdown.classList.remove('hidden');
-
-  const sorted = [...allTags].sort((a, b) => a.name.localeCompare(b.name, 'de'));
-
-  function renderPanel(filter = '') {
-    panel.innerHTML = '';
-    const f = filter.toLowerCase();
-    const visible = sorted.filter(t => t.name.toLowerCase().includes(f));
-    if (visible.length === 0) {
-      panel.innerHTML = '<div class="tag-no-results">Keine Tags gefunden.</div>';
-      return;
-    }
-    visible.forEach(tag => {
-      const opt = document.createElement('div');
-      opt.className = 'tag-option' + (selectedTags.has(tag.id) ? ' selected' : '');
-      opt.dataset.id = tag.id;
-      opt.innerHTML = `
-        <span class="tag-option-check">
-          ${selectedTags.has(tag.id) ? '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>' : ''}
-        </span>
-        ${tag.name}
-      `;
-      opt.addEventListener('click', () => toggleTag(tag.id, tag.name));
-      panel.appendChild(opt);
-    });
-  }
-
-  function renderChips() {
-    chipsEl.innerHTML = '';
-    selectedTags.forEach(id => {
-      const tag = allTags.find(t => t.id === id);
-      if (!tag) return;
-      const chip = document.createElement('div');
-      chip.className = 'tag-chip';
-      chip.innerHTML = `${tag.name}<button class="tag-chip-remove" data-id="${id}" title="Entfernen">×</button>`;
-      chip.querySelector('.tag-chip-remove').addEventListener('click', e => {
-        e.stopPropagation();
-        toggleTag(id, tag.name);
-      });
-      chipsEl.appendChild(chip);
-    });
-    if (selectedTags.size === 0) {
-      searchEl.placeholder = 'Tags wählen…';
-    } else {
-      searchEl.placeholder = '';
-    }
-    updateInfo();
-  }
-
-  function toggleTag(id, name) {
-    if (selectedTags.has(id)) {
-      selectedTags.delete(id);
-    } else {
-      selectedTags.add(id);
-    }
-    renderChips();
-    renderPanel(searchEl.value);
-  }
-
-  function openPanel() {
-    renderPanel(searchEl.value);
-    panel.classList.remove('hidden');
-  }
-
-  function closePanel() {
-    panel.classList.add('hidden');
-    searchEl.value = '';
-  }
-
-  inputWrap.addEventListener('click', () => {
-    searchEl.focus();
-    openPanel();
+  // createChipDropdown() Factory verwenden
+  tagDropdown = createChipDropdown({
+    containerId:  'tag-dropdown',
+    inputWrapId:  'tag-input-wrap',
+    chipsId:      'tag-chips',
+    searchId:     'tag-search',
+    panelId:      'tag-panel',
+    loadingId:    'tag-loading',
+    items:        allTags,
+    placeholder:  'Tags wählen…',
+    onSelectionChange: (ids) => {
+      // selectedTags (globale Variable) synchron halten
+      selectedTags = ids;
+      updateInfo();
+    },
   });
 
-  searchEl.addEventListener('input', () => renderPanel(searchEl.value));
-  searchEl.addEventListener('focus', () => openPanel());
-
-  document.addEventListener('click', e => {
-    if (!dropdown.contains(e.target)) closePanel();
-  });
-
-  renderChips();
+  // selectedTags auf das gleiche Set zeigen lassen
+  selectedTags = tagDropdown.selectedIds;
 }
 
 // ─── Info-Text ─────────────────────────────────────────────────────────

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -20,8 +20,9 @@ document.addEventListener("DOMContentLoaded", () => {
   checkConnection();
   updateOutputPath();
 
-  $("date-from").addEventListener("change", () => { clearActiveYear(); updateInfo(); });
+  $("date-from").addEventListener("change", () => { clearActiveYear(); updateInfo(); validateSubfolderInput(); });
   $("date-to").addEventListener("change",   () => { clearActiveYear(); updateInfo(); });
+  $("subfolder-input").addEventListener("input", validateSubfolderInput);
 
   $("btn-stage0").addEventListener("click",  () => startExport("stage0"));
   $("btn-stage1").addEventListener("click",  () => startExport("stage1"));
@@ -71,7 +72,9 @@ async function checkConnection() {
   }
 }
 
-// ─── Output-Pfad ──────────────────────────────────────────────────────
+// ─── Output-Pfad + Unterordner (Issue #9) ─────────────────────────────────
+// Allowlist-Regex (spiegelt Backend-Validierung exakt)
+const SUBFOLDER_RE = /^[A-Za-z0-9_\-]{1,50}$/;───
 async function updateOutputPath() {
   try {
     const res  = await fetch("/api/config");
@@ -82,6 +85,36 @@ async function updateOutputPath() {
   } catch {
     $("output-path-text").textContent = "(konfigurierter Ausgabepfad auf dem NAS)";
   }
+}
+
+function getSubfolder() {
+  return ($("subfolder-input").value || "").trim();
+}
+
+function validateSubfolderInput() {
+  const val     = getSubfolder();
+  const errEl   = $("subfolder-error");
+  const preview = $("subfolder-preview");
+
+  if (!val) {
+    errEl.classList.add("hidden");
+    preview.classList.add("hidden");
+    return true;
+  }
+
+  if (!SUBFOLDER_RE.test(val)) {
+    errEl.textContent = "Nur Buchstaben, Zahlen, _ und - erlaubt (keine Leerzeichen, Schrägstriche, Sonderzeichen).";
+    errEl.classList.remove("hidden");
+    preview.classList.add("hidden");
+    return false;
+  }
+
+  errEl.classList.add("hidden");
+  // Pfad-Vorschau: {Jahr}/{Unterordner}/Belege/
+  const year = $("date-from").value ? $("date-from").value.slice(0, 4) : "{Jahr}";
+  preview.textContent = `→ ${year}/${val}/Belege/`;
+  preview.classList.remove("hidden");
+  return true;
 }
 
 // ─── Schnellauswahl Kalenderjahre ─────────────────────────────────────
@@ -441,6 +474,15 @@ async function startExport(mode) {
   const doctypeIds      = doctypeDropdown ? Array.from(doctypeDropdown.selectedIds) : [];
   const yearLabel       = from.slice(0, 4);
   const dateField       = getDateField();
+  const subfolder       = getSubfolder();
+
+  // Clientseitige Subfolder-Validierung (Issue #9)
+  if (subfolder && !SUBFOLDER_RE.test(subfolder)) {
+    $("subfolder-error").textContent = "Ungültiger Unterordner – bitte korrigieren.";
+    $("subfolder-error").classList.remove("hidden");
+    $("subfolder-input").focus();
+    return;
+  }
 
   // Issue #4: Überschreib-Prüfung (false=Abbrechen, true=Überschreiben, "append"=Nur neue)
   const confirmed = await checkExistsAndConfirm(yearLabel, mode);
@@ -481,6 +523,7 @@ async function startExport(mode) {
         date_field:  dateField,
         tag_ids: tagIds, tag_names: tagNames,
         document_type_ids: doctypeIds,
+        subfolder,
         year_label: yearLabel, mode,
         append_mode: appendMode,
       }),

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -28,11 +28,17 @@ document.addEventListener("DOMContentLoaded", () => {
   $("btn-cancel").addEventListener("click",  cancelJob);
   $("new-export-btn").addEventListener("click", resetUI);
 
-  // Pill-Toggle für Datumsfeld
+  // Segmented Control für Datumsfeld (Issue #10)
+  updateDateToggleHint(); // Hilfetext beim initialen Seitenload setzen
   document.querySelectorAll('.pill-btn').forEach(btn => {
     btn.addEventListener('click', () => {
-      document.querySelectorAll('.pill-btn').forEach(b => b.classList.remove('pill-active'));
+      document.querySelectorAll('.pill-btn').forEach(b => {
+        b.classList.remove('pill-active');
+        b.setAttribute('aria-pressed', 'false');
+      });
       btn.classList.add('pill-active');
+      btn.setAttribute('aria-pressed', 'true');
+      updateDateToggleHint();
     });
   });
 });
@@ -105,6 +111,19 @@ function clearActiveYear() {
 function getDateField() {
   const active = document.querySelector('.pill-btn.pill-active');
   return active ? active.dataset.value : 'created';
+}
+
+// ─── Datumsfeld-Hilfetext (Issue #10) ──────────────────────────────────────
+const DATE_TOGGLE_HINTS = {
+  created: 'Filtert nach dem Datum auf der Rechnung ("created" in Paperless)',
+  added:   'Filtert nach dem Datum, an dem das Dokument in Paperless eingescannt wurde',
+};
+
+function updateDateToggleHint() {
+  const hintEl = $('date-toggle-hint');
+  if (!hintEl) return;
+  const field = getDateField();
+  hintEl.textContent = DATE_TOGGLE_HINTS[field] || '';
 }
 
 // ─── createChipDropdown() Factory ────────────────────────────────────

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2,8 +2,9 @@
 
 const $ = id => document.getElementById(id);
 
-let allTags      = [];
-let selectedTags = new Set();
+let allTags          = [];
+let selectedTags     = new Set();
+let doctypeDropdown  = null;  // createChipDropdown Handle für Dokumenttypen
 let pollTimer    = null;   // setTimeout-Handle (ersetzt setInterval)
 let pollRunning  = false;  // true solange ein fetch läuft → keine Parallelinstanz
 let lastLogCount = 0;
@@ -15,6 +16,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   buildYearButtons();
   loadTags();
+  loadDocumentTypes();
   checkConnection();
   updateOutputPath();
 
@@ -248,6 +250,40 @@ function createChipDropdown(config) {
   };
 }
 
+// ─── Dokumenttypen laden (Issue #7) ───────────────────────────────────
+async function loadDocumentTypes() {
+  try {
+    const res  = await fetch('/api/document-types');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (data.error) throw new Error(data.error);
+
+    const types = data.document_types || [];
+    if (types.length === 0) {
+      // Keine Typen vorhanden – Lade-Spinner ausblenden, kein Fehler
+      $('doctype-loading').classList.add('hidden');
+      return;
+    }
+
+    doctypeDropdown = createChipDropdown({
+      containerId:  'doctype-dropdown',
+      inputWrapId:  'doctype-input-wrap',
+      chipsId:      'doctype-chips',
+      searchId:     'doctype-search',
+      panelId:      'doctype-panel',
+      loadingId:    'doctype-loading',
+      items:        types,
+      placeholder:  'Typ wählen…',
+      onSelectionChange: () => updateInfo(),
+    });
+  } catch (err) {
+    $('doctype-loading').classList.add('hidden');
+    const errEl = $('doctype-error');
+    errEl.textContent = `Fehler beim Laden der Dokumenttypen: ${err.message}`;
+    errEl.classList.remove('hidden');
+  }
+}
+
 // ─── Tags laden ────────────────────────────────────────────────────────
 async function loadTags() {
   try {
@@ -400,10 +436,11 @@ async function startExport(mode) {
     return;
   }
 
-  const tagIds    = Array.from(selectedTags);
-  const tagNames  = tagIds.map(id => { const t = allTags.find(t => t.id === id); return t ? t.name : String(id); });
-  const yearLabel = from.slice(0, 4);
-  const dateField = getDateField();
+  const tagIds          = Array.from(selectedTags);
+  const tagNames        = tagIds.map(id => { const t = allTags.find(t => t.id === id); return t ? t.name : String(id); });
+  const doctypeIds      = doctypeDropdown ? Array.from(doctypeDropdown.selectedIds) : [];
+  const yearLabel       = from.slice(0, 4);
+  const dateField       = getDateField();
 
   // Issue #4: Überschreib-Prüfung (false=Abbrechen, true=Überschreiben, "append"=Nur neue)
   const confirmed = await checkExistsAndConfirm(yearLabel, mode);
@@ -443,6 +480,7 @@ async function startExport(mode) {
         date_from: from, date_to: to,
         date_field:  dateField,
         tag_ids: tagIds, tag_names: tagNames,
+        document_type_ids: doctypeIds,
         year_label: yearLabel, mode,
         append_mode: appendMode,
       }),

--- a/templates/index.html
+++ b/templates/index.html
@@ -175,15 +175,31 @@
           </div>
         </details>
 
-        <!-- 7. Ausgabepfad (ans Ende) -->
+        <!-- 7. Ausgabepfad + Unterordner (Issue #9) -->
         <div class="field-group" style="margin-top: 12px;">
-          <label class="field-label">Ausgabepfad</label>
-          <div class="output-path">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
-            </svg>
-            <span id="output-path-text">…</span>
+          <label class="field-label" for="subfolder-input">
+            Unterordner
+            <span class="hint">Optional – z.B. "2024-Q4" oder "Archiv"</span>
+          </label>
+          <div class="subfolder-row">
+            <div class="output-path output-path-base">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+              </svg>
+              <span id="output-path-text">…</span>
+            </div>
+            <input
+              type="text"
+              class="input input-subfolder"
+              id="subfolder-input"
+              placeholder="(kein Unterordner)"
+              maxlength="50"
+              autocomplete="off"
+              spellcheck="false"
+            />
           </div>
+          <div class="subfolder-error error-msg hidden" id="subfolder-error"></div>
+          <div class="subfolder-preview hidden" id="subfolder-preview"></div>
         </div>
       </section>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -69,8 +69,32 @@
           <span class="date-toggle-hint" id="date-toggle-hint"></span>
         </div>
 
-        <!-- 4. Tag-Auswahl (Chip-Dropdown) -->
+        <!-- 4a. Dokumententyp-Filter (Issue #7) -->
         <div class="field-group" style="margin-top: 20px;">
+          <label class="field-label">
+            Dokumententyp
+            <span class="hint">Kein Typ = alle Dokumenttypen im Zeitraum</span>
+          </label>
+          <div id="doctype-loading" class="tag-loading">Lade Dokumenttypen…</div>
+          <div id="doctype-error" class="error-msg hidden"></div>
+
+          <div class="tag-dropdown hidden" id="doctype-dropdown">
+            <div class="tag-input-wrap" id="doctype-input-wrap">
+              <div class="tag-chips" id="doctype-chips"></div>
+              <input
+                type="text"
+                class="tag-search"
+                id="doctype-search"
+                placeholder="Typ wählen…"
+                autocomplete="off"
+              />
+            </div>
+            <div class="tag-panel hidden" id="doctype-panel"></div>
+          </div>
+        </div>
+
+        <!-- 4b. Tag-Auswahl (Chip-Dropdown) -->
+        <div class="field-group" style="margin-top: 16px;">
           <label class="field-label">
             Tags filtern
             <span class="hint">Kein Tag = alle Dokumente im Zeitraum</span>
@@ -78,12 +102,9 @@
           <div id="tag-loading" class="tag-loading">Lade Tags aus Paperless…</div>
           <div id="tag-error" class="error-msg hidden"></div>
 
-          <!-- Chip-Dropdown (initial hidden, wird durch JS befüllt) -->
           <div class="tag-dropdown hidden" id="tag-dropdown">
             <div class="tag-input-wrap" id="tag-input-wrap">
-              <div class="tag-chips" id="tag-chips">
-                <!-- gewählte Tags erscheinen hier als Chips -->
-              </div>
+              <div class="tag-chips" id="tag-chips"></div>
               <input
                 type="text"
                 class="tag-search"
@@ -92,9 +113,7 @@
                 autocomplete="off"
               />
             </div>
-            <div class="tag-panel hidden" id="tag-panel">
-              <!-- Optionen werden per JS befüllt -->
-            </div>
+            <div class="tag-panel hidden" id="tag-panel"></div>
           </div>
         </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,13 +55,18 @@
             <input class="input" type="date" id="date-to" />
           </div>
         </div>
-        <div class="date-filter-toggle">
-          <button type="button" class="pill-btn pill-active" id="pill-created" data-value="created">
-            Belegdatum
-          </button>
-          <button type="button" class="pill-btn" id="pill-added" data-value="added">
-            Scan-Datum
-          </button>
+        <div class="date-filter-row">
+          <div class="date-filter-toggle" role="group" aria-label="Datumsfeld-Auswahl">
+            <button type="button" class="pill-btn pill-active" id="pill-created" data-value="created"
+                    aria-pressed="true">
+              Rechnungsdatum
+            </button>
+            <button type="button" class="pill-btn" id="pill-added" data-value="added"
+                    aria-pressed="false">
+              Scandatum
+            </button>
+          </div>
+          <span class="date-toggle-hint" id="date-toggle-hint"></span>
         </div>
 
         <!-- 4. Tag-Auswahl (Chip-Dropdown) -->
@@ -220,7 +225,7 @@
     <footer class="footer">
       <a href="http://www.kommevent.at/" target="_blank">komm|event</a>
       · Agentur für Kommunikation &amp; Events
-      · Steuerberater Export v2.1 · <span id="footer-year"></span>
+      · Steuerberater Export v2.2 · <span id="footer-year"></span>
     </footer>
 
   </div>

--- a/tests/test_excel.py
+++ b/tests/test_excel.py
@@ -10,7 +10,7 @@ import tempfile
 # Projektpfad
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from excel_export import _build_unc_path, create_excel, append_to_excel
+from excel_export import _build_unc_path, _build_cell_formula, create_excel, append_to_excel
 
 
 # ---------------------------------------------------------------------------
@@ -126,18 +126,19 @@ class TestCreateExcel:
         wb.close()
 
     def test_no_subfolder_no_subfolder_in_hyperlink(self, tmp_path):
-        """Ohne Subfolder darf 'Archiv' oder ähnliches NICHT im Pfad stehen."""
+        """Ohne Subfolder: UNC-Modus muss Jahr + Belege im Pfad enthalten."""
         import openpyxl
         out = str(tmp_path / "test_no_sub.xlsx")
         create_excel(
             self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
-            unc_base=self.UNC_BASE
+            unc_base=self.UNC_BASE,
+            hyperlink_mode="unc",
         )
         wb = openpyxl.load_workbook(out)
         ws = wb["Rechnungsaufstellung"]
         cell_j = ws.cell(row=5, column=10)
         val = str(cell_j.value or "")
-        # Standard-Pfad muss direkt \2024\Belege\ enthalten
+        # UNC-Pfad muss Jahr und Belege-Ordner enthalten, aber keinen doppelten Separator
         assert r"\2024\Belege\\" not in val  # kein doppelter Separator
         assert "2024" in val
         assert "Belege" in val
@@ -184,15 +185,114 @@ class TestAppendToExcel:
 
 
 # ---------------------------------------------------------------------------
-# Platzhalter für Schritt 4 (Issue #8) – CELL-Formel Tests
+# Tests: _build_cell_formula() (Issue #8)
+# ---------------------------------------------------------------------------
+
+class TestBuildCellFormula:
+    def test_formula_starts_with_hyperlink(self):
+        formula = _build_cell_formula(r"Belege\test.pdf")
+        assert formula.startswith("=HYPERLINK(")
+
+    def test_formula_contains_cell_filename(self):
+        formula = _build_cell_formula(r"Belege\test.pdf")
+        assert 'CELL("filename")' in formula
+
+    def test_formula_display_name_is_filename(self):
+        formula = _build_cell_formula(r"Belege\test.pdf")
+        assert '"test.pdf"' in formula
+
+    def test_formula_with_subfolder(self):
+        formula = _build_cell_formula(r"Archiv\Belege\test.pdf")
+        assert 'CELL("filename")' in formula
+        assert '"test.pdf"' in formula
+
+    def test_formula_is_dynamic_no_static_path(self):
+        """Wichtigste Eigenschaft: kein statischer absoluter Pfad eingebettet."""
+        formula = _build_cell_formula(r"Belege\test.pdf")
+        assert "C:\\" not in formula
+        assert "\\\\SynologyDS923" not in formula
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_excel() – CELL-Formel vs. UNC (Issue #8)
 # ---------------------------------------------------------------------------
 
 class TestCellFormulaHyperlinks:
-    """
-    TODO (Schritt 4 / Issue #8):
-    - test_hyperlink_mode_cell_generates_formula()
-    - test_hyperlink_mode_unc_generates_absolute_path()
-    - test_include_text_path_adds_column_k()
-    - test_cell_formula_contains_filename()
-    """
-    pass
+    SAMPLE_DOCS = [
+        {"id": 1, "archive_serial_number": "0001", "created": "2024-01-10",
+         "correspondent_name": "Firma A", "title": "Rechnung 1",
+         "document_type": 1, "document_type_name": "Rechnung"},
+    ]
+    PDF_MAP = {1: "0001_Test.pdf"}
+    UNC_BASE = r"\\SynologyDS923\downloads\steuerberater"
+
+    def test_hyperlink_mode_cell_generates_formula(self, tmp_path):
+        """hyperlink_mode='cell' muss CELL("filename")-Formel in Spalte J erzeugen."""
+        import openpyxl
+        out = str(tmp_path / "cell_mode.xlsx")
+        create_excel(self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+                     unc_base=self.UNC_BASE, hyperlink_mode="cell")
+        wb = openpyxl.load_workbook(out)
+        ws = wb["Rechnungsaufstellung"]
+        cell_j = ws.cell(row=5, column=10)
+        val = str(cell_j.value or "")
+        assert 'CELL("filename")' in val
+        assert "=HYPERLINK(" in val
+        wb.close()
+
+    def test_hyperlink_mode_unc_generates_absolute_path(self, tmp_path):
+        """hyperlink_mode='unc' muss absoluten UNC-Pfad erzeugen (kein CELL)."""
+        import openpyxl
+        out = str(tmp_path / "unc_mode.xlsx")
+        create_excel(self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+                     unc_base=self.UNC_BASE, hyperlink_mode="unc")
+        wb = openpyxl.load_workbook(out)
+        ws = wb["Rechnungsaufstellung"]
+        cell_j = ws.cell(row=5, column=10)
+        val = str(cell_j.value or "")
+        assert "SynologyDS923" in val
+        assert 'CELL("filename")' not in val
+        wb.close()
+
+    def test_include_text_path_adds_column_k(self, tmp_path):
+        """include_text_path=True muss Spalte K mit UNC-Pfad erzeugen."""
+        import openpyxl
+        out = str(tmp_path / "text_path.xlsx")
+        create_excel(self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+                     unc_base=self.UNC_BASE, include_text_path=True)
+        wb = openpyxl.load_workbook(out)
+        ws = wb["Rechnungsaufstellung"]
+        # Header Zeile 4, Spalte K
+        header_k = ws.cell(row=4, column=11).value
+        assert header_k is not None and "Pfad" in str(header_k)
+        # Daten Zeile 5, Spalte K
+        data_k = ws.cell(row=5, column=11).value
+        assert data_k is not None
+        assert "SynologyDS923" in str(data_k)
+        wb.close()
+
+    def test_no_text_path_column_k_empty(self, tmp_path):
+        """include_text_path=False (default) darf keine Spalte K erzeugen."""
+        import openpyxl
+        out = str(tmp_path / "no_text_path.xlsx")
+        create_excel(self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+                     unc_base=self.UNC_BASE, include_text_path=False)
+        wb = openpyxl.load_workbook(out)
+        ws = wb["Rechnungsaufstellung"]
+        data_k = ws.cell(row=5, column=11).value
+        assert data_k is None
+        wb.close()
+
+    def test_cell_formula_no_static_path_embedded(self, tmp_path):
+        """Wichtigste Eigenschaft: CELL-Formel enthält keinen statischen Server-Pfad."""
+        import openpyxl
+        out = str(tmp_path / "no_static.xlsx")
+        create_excel(self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+                     unc_base=self.UNC_BASE, hyperlink_mode="cell")
+        wb = openpyxl.load_workbook(out)
+        ws = wb["Rechnungsaufstellung"]
+        cell_j = ws.cell(row=5, column=10)
+        val = str(cell_j.value or "")
+        # Kein statischer NAS-Pfad in der Formel
+        assert "SynologyDS923" not in val
+        wb.close()

--- a/tests/test_excel.py
+++ b/tests/test_excel.py
@@ -1,0 +1,198 @@
+"""
+Tests für excel_export.py – UNC-Pfad-Logik und Subfolder-Schnittstelle.
+Erweitert in Schritt 4 (Issue #8) um CELL-Formel-Tests.
+"""
+import pytest
+import sys
+import os
+import tempfile
+
+# Projektpfad
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from excel_export import _build_unc_path, create_excel, append_to_excel
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_unc_path()
+# ---------------------------------------------------------------------------
+
+class TestBuildUncPath:
+    UNC_BASE   = r"\\SynologyDS923\downloads\steuerberater"
+    YEAR       = "2024"
+    FILENAME   = "0012_Telekom.pdf"
+
+    def test_standard_path_no_subfolder(self):
+        result = _build_unc_path(self.UNC_BASE, self.YEAR, self.FILENAME)
+        assert result == r"\\SynologyDS923\downloads\steuerberater\2024\Belege\0012_Telekom.pdf"
+
+    def test_path_with_subfolder(self):
+        result = _build_unc_path(self.UNC_BASE, self.YEAR, self.FILENAME, subfolder="Archiv")
+        assert result == r"\\SynologyDS923\downloads\steuerberater\2024\Archiv\Belege\0012_Telekom.pdf"
+
+    def test_empty_subfolder_equals_no_subfolder(self):
+        result_empty   = _build_unc_path(self.UNC_BASE, self.YEAR, self.FILENAME, subfolder="")
+        result_default = _build_unc_path(self.UNC_BASE, self.YEAR, self.FILENAME)
+        assert result_empty == result_default
+
+    def test_trailing_backslash_in_base_stripped(self):
+        base_with_slash = self.UNC_BASE + "\\"
+        result = _build_unc_path(base_with_slash, self.YEAR, self.FILENAME)
+        # Kein doppelter Backslash
+        assert "\\\\" not in result.lstrip("\\\\")
+
+    def test_no_unc_base_returns_filename(self):
+        result = _build_unc_path(None, self.YEAR, self.FILENAME)
+        assert result == self.FILENAME
+
+    def test_no_filename_returns_empty(self):
+        result = _build_unc_path(self.UNC_BASE, self.YEAR, "")
+        assert result == ""
+
+    def test_both_none_returns_empty(self):
+        result = _build_unc_path(None, self.YEAR, None)
+        assert result == ""
+
+    def test_subfolder_with_dash_and_digits(self):
+        result = _build_unc_path(self.UNC_BASE, self.YEAR, self.FILENAME, subfolder="2024-Q4")
+        assert "2024-Q4" in result
+        assert r"\Belege\\" not in result  # kein doppelter Separator
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_excel() – Grundfunktion + subfolder-Parameter
+# ---------------------------------------------------------------------------
+
+class TestCreateExcel:
+    SAMPLE_DOCS = [
+        {
+            "id": 1,
+            "archive_serial_number": "0001",
+            "created": "2024-03-15",
+            "correspondent_name": "Telekom",
+            "title": "Telefonrechnung März",
+            "document_type": 2,
+            "document_type_name": "Rechnung",
+        },
+        {
+            "id": 2,
+            "archive_serial_number": "0002",
+            "created": "2024-06-01",
+            "correspondent_name": None,
+            "title": "Internetrechnung",
+            "document_type": 2,
+            "document_type_name": "Rechnung",
+        },
+    ]
+    PDF_MAP = {1: "0001_Telekom.pdf", 2: "0002_Internet.pdf"}
+    UNC_BASE = r"\\SynologyDS923\downloads\steuerberater"
+
+    def test_creates_file(self, tmp_path):
+        out = str(tmp_path / "test.xlsx")
+        result = create_excel(self.SAMPLE_DOCS, self.PDF_MAP, out, "2024")
+        assert os.path.exists(result)
+        assert os.path.getsize(result) > 0
+
+    def test_creates_file_with_unc(self, tmp_path):
+        out = str(tmp_path / "test_unc.xlsx")
+        result = create_excel(
+            self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+            unc_base=self.UNC_BASE
+        )
+        assert os.path.exists(result)
+
+    def test_creates_file_with_subfolder(self, tmp_path):
+        out = str(tmp_path / "test_subfolder.xlsx")
+        result = create_excel(
+            self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+            unc_base=self.UNC_BASE, subfolder="Archiv"
+        )
+        assert os.path.exists(result)
+
+    def test_subfolder_appears_in_hyperlink(self, tmp_path):
+        """Sicherstellen dass der Subfolder im Hyperlink-Pfad vorkommt."""
+        import openpyxl
+        out = str(tmp_path / "test_hyperlink.xlsx")
+        create_excel(
+            self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+            unc_base=self.UNC_BASE, subfolder="Archiv"
+        )
+        wb = openpyxl.load_workbook(out)
+        ws = wb["Rechnungsaufstellung"]
+        # Spalte J ab Zeile 5 – Hyperlink-Formel prüfen
+        cell_j = ws.cell(row=5, column=10)
+        assert cell_j.value is not None
+        assert "Archiv" in str(cell_j.value)
+        wb.close()
+
+    def test_no_subfolder_no_subfolder_in_hyperlink(self, tmp_path):
+        """Ohne Subfolder darf 'Archiv' oder ähnliches NICHT im Pfad stehen."""
+        import openpyxl
+        out = str(tmp_path / "test_no_sub.xlsx")
+        create_excel(
+            self.SAMPLE_DOCS, self.PDF_MAP, out, "2024",
+            unc_base=self.UNC_BASE
+        )
+        wb = openpyxl.load_workbook(out)
+        ws = wb["Rechnungsaufstellung"]
+        cell_j = ws.cell(row=5, column=10)
+        val = str(cell_j.value or "")
+        # Standard-Pfad muss direkt \2024\Belege\ enthalten
+        assert r"\2024\Belege\\" not in val  # kein doppelter Separator
+        assert "2024" in val
+        assert "Belege" in val
+        wb.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: append_to_excel() – subfolder-Parameter
+# ---------------------------------------------------------------------------
+
+class TestAppendToExcel:
+    INITIAL_DOCS = [
+        {"id": 1, "archive_serial_number": "0001", "created": "2024-01-10",
+         "correspondent_name": "Firma A", "title": "Rechnung 1",
+         "document_type": 1, "document_type_name": "Rechnung"},
+    ]
+    NEW_DOCS = [
+        {"id": 2, "archive_serial_number": "0002", "created": "2024-07-20",
+         "correspondent_name": "Firma B", "title": "Rechnung 2",
+         "document_type": 1, "document_type_name": "Rechnung"},
+    ]
+    PDF_MAP = {1: "0001.pdf", 2: "0002.pdf"}
+    UNC_BASE = r"\\SynologyDS923\downloads\steuerberater"
+
+    def test_append_adds_row(self, tmp_path):
+        out = str(tmp_path / "append_test.xlsx")
+        create_excel(self.INITIAL_DOCS, self.PDF_MAP, out, "2024", unc_base=self.UNC_BASE)
+        added = append_to_excel(self.NEW_DOCS, self.PDF_MAP, out, "2024", unc_base=self.UNC_BASE)
+        assert added == 1
+
+    def test_append_with_subfolder(self, tmp_path):
+        out = str(tmp_path / "append_subfolder.xlsx")
+        create_excel(self.INITIAL_DOCS, self.PDF_MAP, out, "2024",
+                     unc_base=self.UNC_BASE, subfolder="Q1")
+        added = append_to_excel(self.NEW_DOCS, self.PDF_MAP, out, "2024",
+                                 unc_base=self.UNC_BASE, subfolder="Q1")
+        assert added == 1
+
+    def test_append_empty_list_returns_zero(self, tmp_path):
+        out = str(tmp_path / "append_empty.xlsx")
+        create_excel(self.INITIAL_DOCS, self.PDF_MAP, out, "2024")
+        added = append_to_excel([], self.PDF_MAP, out, "2024")
+        assert added == 0
+
+
+# ---------------------------------------------------------------------------
+# Platzhalter für Schritt 4 (Issue #8) – CELL-Formel Tests
+# ---------------------------------------------------------------------------
+
+class TestCellFormulaHyperlinks:
+    """
+    TODO (Schritt 4 / Issue #8):
+    - test_hyperlink_mode_cell_generates_formula()
+    - test_hyperlink_mode_unc_generates_absolute_path()
+    - test_include_text_path_adds_column_k()
+    - test_cell_formula_contains_filename()
+    """
+    pass

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,139 @@
+"""
+Sicherheitstests für subfolder-Validierung (Issue #9).
+Allowlist-Ansatz: nur [A-Za-z0-9_-]{1,50} erlaubt.
+"""
+import pytest
+import sys
+import os
+
+# Projektpfad zum sys.path hinzufügen
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktion (wird in Schritt 3 / Issue #9 in app.py implementiert)
+# Vorläufig hier inline definiert damit der Test-Run bereits grün ist.
+# ---------------------------------------------------------------------------
+import re
+
+def _validate_subfolder(name: str) -> str:
+    """
+    Allowlist-Validierung für Unterordner-Namen.
+    Erlaubt: Buchstaben, Zahlen, Unterstriche, Bindestriche (1–50 Zeichen).
+    Leerer String wird akzeptiert (kein Unterordner gewünscht).
+    """
+    if not name:
+        return ""
+    name = name.strip()  # Whitespace außen entfernen
+    if not name:          # nach strip() leer (war nur Whitespace) → erlaubt
+        return ""
+    if not re.fullmatch(r"[A-Za-z0-9_\-]{1,50}", name):
+        raise ValueError(
+            f"Ungültiger Unterordner-Name: '{name}'. "
+            "Nur Buchstaben, Zahlen, _ und - erlaubt (max. 50 Zeichen)."
+        )
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Tests: Gültige Eingaben
+# ---------------------------------------------------------------------------
+
+class TestValidSubfolder:
+    def test_simple_name(self):
+        assert _validate_subfolder("Archiv") == "Archiv"
+
+    def test_year_quarter(self):
+        assert _validate_subfolder("2024-Q4") == "2024-Q4"
+
+    def test_underscores(self):
+        assert _validate_subfolder("steuer_2024") == "steuer_2024"
+
+    def test_alphanumeric(self):
+        assert _validate_subfolder("Belege2024") == "Belege2024"
+
+    def test_max_length(self):
+        name = "A" * 50
+        assert _validate_subfolder(name) == name
+
+    def test_mixed_case(self):
+        assert _validate_subfolder("MeinOrdner") == "MeinOrdner"
+
+    def test_only_digits(self):
+        assert _validate_subfolder("2024") == "2024"
+
+    def test_leading_trailing_spaces_stripped(self):
+        # strip() wird aufgerufen → Whitespace außen wird entfernt
+        assert _validate_subfolder("  Archiv  ") == "Archiv"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Leere / None Eingaben
+# ---------------------------------------------------------------------------
+
+class TestEmptySubfolder:
+    def test_empty_string(self):
+        assert _validate_subfolder("") == ""
+
+    def test_whitespace_only(self):
+        # Nach strip() → leer → erlaubt
+        assert _validate_subfolder("   ") == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests: Ungültige Eingaben (Path Traversal & Co.)
+# ---------------------------------------------------------------------------
+
+class TestInvalidSubfolder:
+    def test_path_traversal_dotdot(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("../etc")
+
+    def test_path_traversal_absolute(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("/etc/passwd")
+
+    def test_path_traversal_windows(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("..\\Windows\\System32")
+
+    def test_space_in_name(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("Mein Ordner")
+
+    def test_slash_separator(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("folder/sub")
+
+    def test_backslash_separator(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("folder\\sub")
+
+    def test_special_chars(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("name<script>")
+
+    def test_semicolon(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("folder;rm -rf")
+
+    def test_too_long(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("A" * 51)
+
+    def test_dot_only(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder(".")
+
+    def test_double_dot(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("..")
+
+    def test_null_byte(self):
+        with pytest.raises(ValueError):
+            _validate_subfolder("folder\x00name")
+
+    def test_unicode_umlaut(self):
+        # Umlaute sind nicht in der Allowlist → rejected
+        with pytest.raises(ValueError):
+            _validate_subfolder("Büro")


### PR DESCRIPTION
## Summary

Closes #8

Implementiert portable Excel-Hyperlinks mittels `CELL("filename")`-Formel, sodass Ordner-Verschiebungen die Links nicht brechen. Außerdem optionale Spalte K mit kopierbarem UNC-Pfad.

## Changes

### `excel_export.py`
- `_build_cell_formula(subfolder_path)` — baut `=HYPERLINK(LEFT(CELL("filename"),FIND("[",CELL("filename"))-1)&"Belege\datei.pdf","datei.pdf")`
- `create_excel()` + `append_to_excel()`: neuer Parameter `hyperlink_mode` (default `"cell"`) und `include_text_path` (default `False`)
- Spalte K mit kopierbarem UNC-Pfad wenn `include_text_path=True` und `unc_base` gesetzt
- Fix: Raw-Docstring `r"""..."""` behebt SyntaxWarning für `\d`

### `app.py`
- Liest `HYPERLINK_MODE` (default `cell`) und `INCLUDE_TEXT_PATH` (default `false`) aus ENV
- Übergibt Parameter an alle Stage-Funktionen und `api_start`

### `.env.example`
- `HYPERLINK_MODE` und `INCLUDE_TEXT_PATH` dokumentiert

### `tests/test_excel.py`
- `TestBuildCellFormula` — 5 Tests für `_build_cell_formula()`
- `TestCellFormulaHyperlinks` — 5 Tests für `create_excel()` mit CELL- und UNC-Modus
- Fix: `test_no_subfolder_no_subfolder_in_hyperlink` übergibt jetzt explizit `hyperlink_mode="unc"` — UNC-Assertions bleiben korrekt, Default-CELL-Verhalten wird separat getestet

## Test Results

```
49 passed in 0.47s
```

## ENV Variables (neu)

| Variable | Default | Beschreibung |
|---|---|---|
| `HYPERLINK_MODE` | `cell` | `cell` = CELL()-Formel (portabel); `unc` = absoluter UNC-Pfad (bisheriges Verhalten) |
| `INCLUDE_TEXT_PATH` | `false` | Spalte K mit kopierbarem UNC-Pfad anzeigen |

## Pflichttest vor Release (manuell auf NAS)

1. Excel auf NAS speichern unter `\\SynologyDS923\downloads\steuerberater\`
2. Hyperlink in Spalte J klicken → PDF öffnet sich ✓
3. Excel-Datei in anderen Unterordner verschieben
4. Excel öffnen → Link erneut klicken → PDF öffnet sich vom neuen Speicherort ✓
5. Test mit `HYPERLINK_MODE=unc` wiederholen → absoluter Pfad wie bisher ✓

## Rollback

`HYPERLINK_MODE=unc` in `.env` → exakt das Verhalten von v2.1 wird wiederhergestellt.