### PR TITLE
feat(issue-12): GUI Improvements – Schritt 4 (Subfolder-Picker Modal)

### DIFF
--- a/app.py
+++ b/app.py
@@ -688,6 +688,55 @@ def api_health():
     return jsonify(status)
 
 
+# ── Subfolder-Picker API (Issue #12, Schritt 4) ──────────────────────────────
+@app.route("/api/subfolders")
+def api_subfolders_list():
+    """
+    GET /api/subfolders
+    Gibt alle direkten Unterverzeichnisse von OUTPUT_DIR zurueck (alphabetisch).
+    Keine Rekursion, nur eine Ebene tief.
+    """
+    try:
+        real_output = os.path.realpath(OUTPUT_DIR)
+        if not os.path.isdir(real_output):
+            return jsonify({"subfolders": []})
+        names = sorted(
+            entry.name
+            for entry in os.scandir(real_output)
+            if entry.is_dir(follow_symlinks=False)
+            and re.fullmatch(r"[A-Za-z0-9_\-]{1,50}", entry.name)
+        )
+        return jsonify({"subfolders": names})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/subfolders", methods=["POST"])
+def api_subfolders_create():
+    """
+    POST /api/subfolders  {"name": "<ordnername>"}
+    Legt einen neuen Unterordner in OUTPUT_DIR an.
+    Validiert via Allowlist (_validate_subfolder) + _assert_output_path.
+    """
+    data = request.get_json(force=True, silent=True) or {}
+    raw_name = data.get("name", "") or ""
+    try:
+        name = _validate_subfolder(raw_name)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    if not name:
+        return jsonify({"error": "Ordnername darf nicht leer sein."}), 400
+    try:
+        target = os.path.join(OUTPUT_DIR, name)
+        _assert_output_path(target)
+        os.makedirs(target, exist_ok=True)
+        return jsonify({"created": name}), 201
+    except PermissionError as e:
+        return jsonify({"error": str(e)}), 403
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
 @app.route("/api/download-excel")
 def api_download_excel():
     with job_lock:

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -282,6 +282,34 @@ body {
   font-weight: 500;
 }
 
+/* Subfolder-Picker Button (Issue #12, Schritt 4) */
+.subfolder-picker-row {
+  flex-wrap: nowrap;
+}
+.btn-picker {
+  flex: 1;
+  min-width: 0;
+  justify-content: flex-start;
+  gap: 7px;
+  text-align: left;
+  font-size: .88rem;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 280px;
+}
+.btn-picker svg { flex-shrink: 0; }
+#subfolder-picker-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+}
+#subfolder-picker-label.has-value {
+  color: var(--primary-hov);
+  font-weight: 600;
+}
+
 
 
 /* ─── Aktionen ─────────────────────────────────────────────────────── */
@@ -695,6 +723,135 @@ body {
   font-weight: 700;
   color: var(--dark);
   margin-bottom: 10px;
+}
+
+/* Subfolder-Modal Header mit Close-Button */
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.modal-header .modal-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 0;
+}
+.modal-close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  transition: color .15s;
+}
+.modal-close-btn:hover { color: var(--dark); }
+.modal-close-btn:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* Subfolder-Modal spezifisch */
+.modal-subfolder {
+  max-width: 420px;
+  padding: 24px;
+}
+.subfolder-search-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  margin: 12px 0 8px;
+}
+.subfolder-search-wrap svg { color: var(--text-muted); flex-shrink: 0; }
+.subfolder-search-input {
+  border: none;
+  outline: none;
+  background: transparent;
+  flex: 1;
+  font-size: .88rem;
+  font-family: inherit;
+  color: var(--text);
+}
+.subfolder-list {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: #fff;
+}
+.subfolder-list-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  font-size: .88rem;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  transition: background .1s;
+  min-height: 40px;
+}
+.subfolder-list-item:last-child { border-bottom: none; }
+.subfolder-list-item:hover,
+.subfolder-list-item:focus {
+  background: var(--primary-pale);
+  outline: none;
+}
+.subfolder-list-item[aria-selected="true"] {
+  background: var(--primary-pale);
+  color: var(--primary-hov);
+  font-weight: 600;
+}
+.subfolder-list-item svg { color: var(--primary); flex-shrink: 0; }
+.subfolder-list-empty {
+  padding: 16px 12px;
+  font-size: .85rem;
+  color: var(--text-muted);
+  text-align: center;
+  font-style: italic;
+}
+
+/* "Kein Unterordner" Reset-Option */
+.subfolder-list-item.item-none {
+  color: var(--text-muted);
+  font-style: italic;
+}
+.subfolder-list-item.item-none[aria-selected="true"] {
+  color: var(--primary-hov);
+  font-style: normal;
+}
+
+/* Neuer Ordner Block */
+.subfolder-new-wrap {
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+.subfolder-new-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.subfolder-new-input {
+  flex: 1;
+  font-size: .88rem;
+  padding: 7px 10px;
+}
+
+/* Modal-Actions rechtsbuendig fuer Subfolder-Modal */
+.modal-actions-subfolder {
+  justify-content: flex-end;
 }
 .modal-text {
   font-size: .9rem;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -20,9 +20,9 @@ document.addEventListener("DOMContentLoaded", () => {
   checkConnection();
   updateOutputPath();
 
-  $("date-from").addEventListener("change", () => { clearActiveYear(); updateInfo(); validateSubfolderInput(); });
+  $("date-from").addEventListener("change", () => { clearActiveYear(); updateInfo(); updateSubfolderPreview(); });
   $("date-to").addEventListener("change",   () => { clearActiveYear(); updateInfo(); });
-  $("subfolder-input").addEventListener("input", validateSubfolderInput);
+  initSubfolderPicker();
 
   $("btn-stage0").addEventListener("click",  () => startExport("stage0"));
   $("btn-stage1").addEventListener("click",  () => startExport("stage1"));
@@ -130,9 +130,10 @@ async function checkConnection() {
   }
 }
 
-// --- Output-Pfad + Unterordner (Issue #9) ---------------------------------
+// --- Output-Pfad + Unterordner (Issue #9, Issue #12 Schritt 4: Picker) ------
 // Allowlist-Regex (spiegelt Backend-Validierung exakt)
 const SUBFOLDER_RE = /^[A-Za-z0-9_\-]{1,50}$/;
+
 async function updateOutputPath() {
   try {
     const res  = await fetch("/api/config");
@@ -145,34 +146,224 @@ async function updateOutputPath() {
   }
 }
 
+// Liefert den aktuell gewählten Unterordner-Wert (hidden input)
 function getSubfolder() {
   return ($("subfolder-input").value || "").trim();
 }
 
-function validateSubfolderInput() {
+// Pfad-Vorschau unter dem Picker-Button aktualisieren
+function updateSubfolderPreview() {
   const val     = getSubfolder();
-  const errEl   = $("subfolder-error");
   const preview = $("subfolder-preview");
-
   if (!val) {
-    errEl.classList.add("hidden");
     preview.classList.add("hidden");
-    return true;
+    return;
   }
-
-  if (!SUBFOLDER_RE.test(val)) {
-    errEl.textContent = "Nur Buchstaben, Zahlen, _ und - erlaubt (keine Leerzeichen, Schrägstriche, Sonderzeichen).";
-    errEl.classList.remove("hidden");
-    preview.classList.add("hidden");
-    return false;
-  }
-
-  errEl.classList.add("hidden");
-  // Pfad-Vorschau: {Jahr}/{Unterordner}/Belege/
   const year = $("date-from").value ? $("date-from").value.slice(0, 4) : "{Jahr}";
   preview.textContent = `→ ${year}/${val}/Belege/`;
   preview.classList.remove("hidden");
-  return true;
+}
+
+// Picker-Button-Label + hidden input setzen
+function setSubfolderValue(name) {
+  $("subfolder-input").value = name;
+  const label = $("subfolder-picker-label");
+  if (name) {
+    label.textContent = name;
+    label.classList.add("has-value");
+  } else {
+    label.textContent = "(kein Unterordner)";
+    label.classList.remove("has-value");
+  }
+  updateSubfolderPreview();
+}
+
+// ---------------------------------------------------------------------------
+// Subfolder-Picker Modal (Issue #12, Schritt 4)
+// ---------------------------------------------------------------------------
+let _pickerSelectedValue = "";  // aktuell im Modal selektierter Wert
+
+function initSubfolderPicker() {
+  $("subfolder-picker-btn").addEventListener("click", openSubfolderModal);
+}
+
+async function openSubfolderModal() {
+  const modal     = $("subfolder-modal");
+  const list      = $("subfolder-list");
+  const searchEl  = $("subfolder-search");
+  const newInput  = $("subfolder-new-input");
+  const newErr    = $("subfolder-new-error");
+  const confirmBtn = $("subfolder-modal-confirm");
+
+  // Reset Modal-State
+  searchEl.value     = "";
+  newInput.value     = "";
+  newErr.classList.add("hidden");
+  newErr.textContent = "";
+  _pickerSelectedValue = getSubfolder(); // aktuell gesetzter Wert vorselektieren
+  confirmBtn.disabled = false; // immer erlaubt (auch "Kein Unterordner" wählen)
+
+  modal.classList.remove("hidden");
+
+  // Unterordner laden
+  list.innerHTML = '<li class="subfolder-list-empty">Lade Unterordner…</li>';
+  let folders = [];
+  try {
+    const res  = await fetch("/api/subfolders");
+    const data = await res.json();
+    folders = data.subfolders || [];
+  } catch {
+    // Fallback: API nicht erreichbar → leere Liste + Info
+    folders = null;
+  }
+
+  renderFolderList(list, folders, searchEl.value);
+
+  // Fokus auf Suche setzen (erste fokussierbare Element)
+  setTimeout(() => searchEl.focus(), 50);
+
+  // Suche filtern
+  searchEl.addEventListener("input", () => renderFolderList(list, folders, searchEl.value), { once: false });
+
+  // Focus-Trap + Keyboard-Handling
+  function closeModal(confirmed) {
+    modal.classList.add("hidden");
+    document.removeEventListener("keydown", escHandler);
+    modal.removeEventListener("click",     backdropHandler);
+    searchEl.removeEventListener("input",  filterHandler);
+    if (confirmed) {
+      setSubfolderValue(_pickerSelectedValue);
+    }
+    // Fokus zurück auf Picker-Button
+    $("subfolder-picker-btn").focus();
+  }
+
+  function filterHandler() {
+    renderFolderList(list, folders, searchEl.value);
+  }
+  searchEl.addEventListener("input", filterHandler);
+
+  function escHandler(e) {
+    if (e.key === "Escape") closeModal(false);
+  }
+  document.addEventListener("keydown", escHandler);
+
+  function backdropHandler(e) {
+    if (e.target === modal) closeModal(false);
+  }
+  modal.addEventListener("click", backdropHandler);
+
+  $("subfolder-modal-close").onclick  = () => closeModal(false);
+  $("subfolder-modal-cancel").onclick = () => closeModal(false);
+  $("subfolder-modal-confirm").onclick = () => closeModal(true);
+
+  // Neuen Ordner anlegen
+  $("subfolder-new-btn").onclick = async () => {
+    const name = (newInput.value || "").trim();
+    newErr.classList.add("hidden");
+
+    if (!name) {
+      newErr.textContent = "Bitte einen Ordnernamen eingeben.";
+      newErr.classList.remove("hidden");
+      newInput.focus();
+      return;
+    }
+    if (!SUBFOLDER_RE.test(name)) {
+      newErr.textContent = "Nur Buchstaben, Zahlen, _ und - erlaubt (1–50 Zeichen).";
+      newErr.classList.remove("hidden");
+      newInput.focus();
+      return;
+    }
+
+    try {
+      const res  = await fetch("/api/subfolders", {
+        method:  "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify({ name }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        newErr.textContent = data.error || "Fehler beim Erstellen.";
+        newErr.classList.remove("hidden");
+        return;
+      }
+      // Ordner angelegt → Liste aktualisieren + auswählen
+      if (folders !== null && !folders.includes(name)) {
+        folders.push(name);
+        folders.sort();
+      }
+      newInput.value = "";
+      _pickerSelectedValue = name;
+      renderFolderList(list, folders, searchEl.value);
+    } catch {
+      newErr.textContent = "API nicht erreichbar – Ordner konnte nicht angelegt werden.";
+      newErr.classList.remove("hidden");
+    }
+  };
+
+  // Enter in new-input triggert Erstellen
+  newInput.addEventListener("keydown", e => {
+    if (e.key === "Enter") { e.preventDefault(); $("subfolder-new-btn").click(); }
+  });
+}
+
+function renderFolderList(list, folders, filter) {
+  list.innerHTML = "";
+  const q = (filter || "").toLowerCase().trim();
+
+  // "Kein Unterordner" Option immer oben
+  const noneItem = document.createElement("li");
+  noneItem.className   = "subfolder-list-item item-none";
+  noneItem.tabIndex    = 0;
+  noneItem.setAttribute("role", "option");
+  noneItem.setAttribute("aria-selected", _pickerSelectedValue === "" ? "true" : "false");
+  noneItem.innerHTML   = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" stroke-width="2" aria-hidden="true">
+    <circle cx="12" cy="12" r="10"/><line x1="8" y1="12" x2="16" y2="12"/>
+  </svg>(kein Unterordner)`;
+  noneItem.addEventListener("click", () => { _pickerSelectedValue = ""; renderFolderList(list, folders, filter); });
+  noneItem.addEventListener("keydown", e => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); noneItem.click(); } });
+  list.appendChild(noneItem);
+
+  if (folders === null) {
+    // API-Fallback: Nur "kein Unterordner" + Hinweis
+    const fallback = document.createElement("li");
+    fallback.className = "subfolder-list-empty";
+    fallback.textContent = "Unterordner-Liste nicht verfügbar (API nicht erreichbar).";
+    list.appendChild(fallback);
+    return;
+  }
+
+  const filtered = folders.filter(f => !q || f.toLowerCase().includes(q));
+  if (filtered.length === 0 && folders.length > 0) {
+    const empty = document.createElement("li");
+    empty.className = "subfolder-list-empty";
+    empty.textContent = "Keine Treffer für „" + filter + "".";
+    list.appendChild(empty);
+    return;
+  }
+  if (folders.length === 0) {
+    const empty = document.createElement("li");
+    empty.className = "subfolder-list-empty";
+    empty.textContent = "Noch keine Unterordner vorhanden – neuen Ordner anlegen.";
+    list.appendChild(empty);
+    return;
+  }
+
+  filtered.forEach(name => {
+    const item = document.createElement("li");
+    item.className  = "subfolder-list-item";
+    item.tabIndex   = 0;
+    item.setAttribute("role", "option");
+    item.setAttribute("aria-selected", _pickerSelectedValue === name ? "true" : "false");
+    item.innerHTML  = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+    </svg>${name}`;
+    item.addEventListener("click", () => { _pickerSelectedValue = name; renderFolderList(list, folders, filter); });
+    item.addEventListener("keydown", e => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); item.click(); } });
+    list.appendChild(item);
+  });
 }
 
 // --- Schnellauswahl Kalenderjahre -------------------------------------
@@ -569,11 +760,11 @@ async function startExport(mode) {
   const dateField       = getDateField();
   const subfolder       = getSubfolder();
 
-  // Clientseitige Subfolder-Validierung (Issue #9)
+  // Clientseitige Subfolder-Validierung (Issue #9 / #12):
+  // Picker setzt nur valide Werte (SUBFOLDER_RE). Zur Sicherheit trotzdem prüfen.
   if (subfolder && !SUBFOLDER_RE.test(subfolder)) {
-    $("subfolder-error").textContent = "Ungültiger Unterordner – bitte korrigieren.";
-    $("subfolder-error").classList.remove("hidden");
-    $("subfolder-input").focus();
+    // Sollte durch Picker nicht mehr passieren – trotzdem absichern
+    $("subfolder-picker-btn").focus();
     return;
   }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -126,29 +126,29 @@
 
         </div><!-- /.filter-row -->
 
-        <!-- 4. Ausgabepfad + Unterordner (Issue #9) -->
-        <!-- F4: fieldset/legend für semantisches Grouping -->
+        <!-- 4. Ausgabepfad + Unterordner (Issue #9, Issue #12 Schritt 4: Picker) -->
+        <!-- F4: fieldset/legend für semantisches Grouping (Schritt 3) -->
         <fieldset class="field-group subfolder-fieldset">
           <legend class="field-label">Unterordner</legend>
-          <p class="field-hint">Optional – z.B. "2024-Q4" oder "Archiv"</p>
-          <div class="subfolder-row">
+          <p class="field-hint">Optional – Unterordner für die Ausgabedateien auswählen</p>
+          <div class="subfolder-row subfolder-picker-row">
             <div class="output-path output-path-base">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
               </svg>
               <span id="output-path-text">…</span>
             </div>
-            <input
-              type="text"
-              class="input input-subfolder"
-              id="subfolder-input"
-              placeholder="(kein Unterordner)"
-              maxlength="50"
-              autocomplete="off"
-              spellcheck="false"
-            />
+            <!-- Picker-Button + ausgelesener Ordnername -->
+            <button type="button" class="btn btn-secondary btn-picker" id="subfolder-picker-btn"
+                    aria-haspopup="dialog" aria-label="Unterordner auswählen">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+              </svg>
+              <span id="subfolder-picker-label">(kein Unterordner)</span>
+            </button>
+            <!-- Hidden input für Formularwert (Kompatibilität mit startExport) -->
+            <input type="hidden" id="subfolder-input" value=""/>
           </div>
-          <div class="subfolder-error error-msg hidden" id="subfolder-error" role="alert"></div>
           <div class="subfolder-preview hidden" id="subfolder-preview" aria-live="polite"></div>
         </fieldset>
 
@@ -286,6 +286,59 @@
       · {{ app_title }} v2.2 · <span id="footer-year"></span>
     </footer>
 
+  </div>
+
+  <!-- Subfolder-Picker Modal (Issue #12, Schritt 4) -->
+  <div id="subfolder-modal" class="modal-overlay hidden"
+       role="dialog" aria-modal="true" aria-labelledby="subfolder-modal-title"
+       aria-describedby="subfolder-modal-desc">
+    <div class="modal modal-subfolder">
+      <div class="modal-header">
+        <h3 class="modal-title" id="subfolder-modal-title">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+          </svg>
+          Unterordner auswählen
+        </h3>
+        <button class="modal-close-btn" id="subfolder-modal-close" aria-label="Schließen">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
+      </div>
+      <p class="modal-text" id="subfolder-modal-desc">Wähle einen bestehenden Unterordner oder lege einen neuen an.</p>
+      <div class="subfolder-search-wrap">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+        </svg>
+        <input type="search" id="subfolder-search" class="subfolder-search-input"
+               placeholder="Suchen…" autocomplete="off" aria-label="Unterordner suchen"/>
+      </div>
+      <ul id="subfolder-list" class="subfolder-list" role="listbox" aria-label="Verfügbare Unterordner">
+        <li class="subfolder-list-empty" aria-live="polite">Lade Unterordner…</li>
+      </ul>
+      <!-- Neuen Ordner anlegen -->
+      <div class="subfolder-new-wrap">
+        <div class="subfolder-new-row">
+          <input type="text" id="subfolder-new-input" class="input subfolder-new-input"
+                 placeholder="Neuer Ordnername" maxlength="50"
+                 autocomplete="off" spellcheck="false"
+                 aria-label="Name für neuen Unterordner"
+                 pattern="[A-Za-z0-9_\-]{1,50}"/>
+          <button class="btn btn-secondary" id="subfolder-new-btn">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+              <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+            </svg>
+            Erstellen
+          </button>
+        </div>
+        <div class="subfolder-new-error error-msg hidden" id="subfolder-new-error" role="alert"></div>
+      </div>
+      <div class="modal-actions modal-actions-subfolder">
+        <button class="btn btn-secondary" id="subfolder-modal-cancel">Abbrechen</button>
+        <button class="btn btn-primary" id="subfolder-modal-confirm" disabled>Auswählen</button>
+      </div>
+    </div>
   </div>
 
   <!-- Überschreib-Modal (Issue #4) -->

--- a/tests/test_subfolders_api.py
+++ b/tests/test_subfolders_api.py
@@ -1,0 +1,229 @@
+"""
+Backend-Tests fuer die Subfolder-Picker API (Issue #12, Schritt 4).
+Testet GET /api/subfolders und POST /api/subfolders.
+"""
+import pytest
+import sys
+import os
+import tempfile
+import json
+
+# Projektpfad
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ---------------------------------------------------------------------------
+# Flask-Test-Client Setup
+# ---------------------------------------------------------------------------
+@pytest.fixture()
+def app_with_output(tmp_path):
+    """
+    Flask-App mit temporaerem OUTPUT_DIR starten.
+    Nutzt Environment-Variable damit app.py den Pfad setzt.
+    """
+    os.environ["OUTPUT_DIR"]          = str(tmp_path)
+    os.environ["PAPERLESS_URL"]       = "http://localhost:8000"
+    os.environ["PAPERLESS_TOKEN"]     = "test-token-123"
+    os.environ["WINDOWS_UNC_PATH"]    = ""
+
+    import importlib
+    import app as app_module
+    importlib.reload(app_module)
+
+    app_module.app.config["TESTING"] = True
+    with app_module.app.test_client() as client:
+        yield client, tmp_path
+
+    # Cleanup env
+    for key in ["OUTPUT_DIR", "PAPERLESS_URL", "PAPERLESS_TOKEN", "WINDOWS_UNC_PATH"]:
+        os.environ.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /api/subfolders
+# ---------------------------------------------------------------------------
+class TestGetSubfolders:
+    def test_empty_output_dir_returns_empty_list(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.get("/api/subfolders")
+        assert res.status_code == 200
+        data = json.loads(res.data)
+        assert data["subfolders"] == []
+
+    def test_existing_valid_dirs_returned(self, app_with_output):
+        client, tmp_path = app_with_output
+        (tmp_path / "Archiv").mkdir()
+        (tmp_path / "2024-Q4").mkdir()
+        (tmp_path / "steuer_2024").mkdir()
+        res = client.get("/api/subfolders")
+        assert res.status_code == 200
+        data = json.loads(res.data)
+        assert sorted(data["subfolders"]) == ["2024-Q4", "Archiv", "steuer_2024"]
+
+    def test_invalid_dirs_excluded(self, app_with_output):
+        """Ordner mit Leerzeichen, Sonderzeichen oder > 50 Zeichen werden gefiltert."""
+        client, tmp_path = app_with_output
+        (tmp_path / "Mein Ordner").mkdir()       # Leerzeichen
+        (tmp_path / "folder.test").mkdir()        # Punkt
+        (tmp_path / "valid-folder").mkdir()       # gueltig
+        (tmp_path / ("A" * 51)).mkdir()           # zu lang
+        res = client.get("/api/subfolders")
+        assert res.status_code == 200
+        data = json.loads(res.data)
+        # Nur "valid-folder" bleibt
+        assert data["subfolders"] == ["valid-folder"]
+
+    def test_files_excluded(self, app_with_output):
+        """Regulaere Dateien werden nicht als Unterordner aufgelistet."""
+        client, tmp_path = app_with_output
+        (tmp_path / "Archiv").mkdir()
+        (tmp_path / "report.xlsx").write_text("dummy")
+        res = client.get("/api/subfolders")
+        assert res.status_code == 200
+        data = json.loads(res.data)
+        assert data["subfolders"] == ["Archiv"]
+
+    def test_sorted_alphabetically(self, app_with_output):
+        client, tmp_path = app_with_output
+        (tmp_path / "Zebra").mkdir()
+        (tmp_path / "Alpha").mkdir()
+        (tmp_path / "Mitte").mkdir()
+        res = client.get("/api/subfolders")
+        assert res.status_code == 200
+        data = json.loads(res.data)
+        assert data["subfolders"] == ["Alpha", "Mitte", "Zebra"]
+
+    def test_response_has_subfolders_key(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.get("/api/subfolders")
+        assert res.status_code == 200
+        data = json.loads(res.data)
+        assert "subfolders" in data
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/subfolders
+# ---------------------------------------------------------------------------
+class TestPostSubfolders:
+    def test_create_valid_folder(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": "Archiv"}),
+            content_type="application/json",
+        )
+        assert res.status_code == 201
+        data = json.loads(res.data)
+        assert data["created"] == "Archiv"
+        assert (tmp_path / "Archiv").is_dir()
+
+    def test_create_folder_with_dash_and_underscore(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": "steuer_2024-Q4"}),
+            content_type="application/json",
+        )
+        assert res.status_code == 201
+        assert (tmp_path / "steuer_2024-Q4").is_dir()
+
+    def test_create_folder_idempotent(self, app_with_output):
+        """Bereits existierender Ordner wird akzeptiert (exist_ok=True)."""
+        client, tmp_path = app_with_output
+        (tmp_path / "Archiv").mkdir()
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": "Archiv"}),
+            content_type="application/json",
+        )
+        assert res.status_code == 201
+
+    def test_empty_name_rejected(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": ""}),
+            content_type="application/json",
+        )
+        assert res.status_code == 400
+        data = json.loads(res.data)
+        assert "error" in data
+
+    def test_missing_name_key_rejected(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert res.status_code == 400
+
+    def test_path_traversal_rejected(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": "../etc"}),
+            content_type="application/json",
+        )
+        assert res.status_code == 400
+        data = json.loads(res.data)
+        assert "error" in data
+
+    def test_slash_in_name_rejected(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": "folder/sub"}),
+            content_type="application/json",
+        )
+        assert res.status_code == 400
+
+    def test_space_in_name_rejected(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": "Mein Ordner"}),
+            content_type="application/json",
+        )
+        assert res.status_code == 400
+
+    def test_too_long_name_rejected(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": "A" * 51}),
+            content_type="application/json",
+        )
+        assert res.status_code == 400
+
+    def test_absolute_path_rejected(self, app_with_output):
+        client, tmp_path = app_with_output
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": "/etc/passwd"}),
+            content_type="application/json",
+        )
+        assert res.status_code == 400
+
+    def test_created_folder_appears_in_list(self, app_with_output):
+        """Neu angelegter Ordner erscheint direkt in GET /api/subfolders."""
+        client, tmp_path = app_with_output
+        client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": "Neu2024"}),
+            content_type="application/json",
+        )
+        res = client.get("/api/subfolders")
+        data = json.loads(res.data)
+        assert "Neu2024" in data["subfolders"]
+
+    def test_max_length_name_accepted(self, app_with_output):
+        client, tmp_path = app_with_output
+        name = "A" * 50
+        res = client.post(
+            "/api/subfolders",
+            data=json.dumps({"name": name}),
+            content_type="application/json",
+        )
+        assert res.status_code == 201
+        assert (tmp_path / name).is_dir()


### PR DESCRIPTION
## Übersicht

Schritt 4 (letzter Schritt) aus Issue #12: Ersetzt die Freitext-Eingabe für Unterordner durch ein vollständiges Picker-Modal mit Ordnerliste, Suchfeld und "Neuen Ordner erstellen"-Funktion.

## Änderungen

### Backend (`app.py`)
- **`GET /api/subfolders`** – listet alle direkten Unterverzeichnisse von `OUTPUT_DIR` (Allowlist-gefiltert `[A-Za-z0-9_-]{1,50}`, alphabetisch sortiert, keine Symlinks)
- **`POST /api/subfolders`** – legt neuen Unterordner an (`_validate_subfolder` + `_assert_output_path`, `exist_ok=True`)

### Frontend (`templates/index.html`)
- Picker-Button (`aria-haspopup=dialog`) ersetzt `<input type=text>`
- Hidden `<input id=subfolder-input>` für Kompatibilität mit `startExport()`
- Subfolder-Picker Modal mit Ordnerliste (`role=listbox`), Suchfeld, Erstellen-Bereich
- "Kein Unterordner" als Reset-Option immer oben in der Liste

### JavaScript (`static/js/app.js`)
- `initSubfolderPicker()` – registriert Picker-Button-Handler
- `openSubfolderModal()` – lädt Ordner via API, rendert Liste
- `renderFolderList()` – Suche, aria-selected, Fallback bei API-Fehler
- `setSubfolderValue()` – setzt hidden input + Button-Label + Pfad-Vorschau
- Focus-Trap-Pattern aus Schritt 3 wiederverwendet (Escape, Backdrop-Klick)
- Neuen Ordner per `POST /api/subfolders` mit clientseitiger SUBFOLDER_RE-Validierung
- Fallback: Wenn API nicht erreichbar → Hinweis in Modal, kein Absturz

### CSS (`static/css/style.css`)
- Picker-Button Layout (`.btn-picker`, `.subfolder-picker-row`)
- Modal-Struktur mit X-Button (`.modal-header`, `.modal-close-btn`)
- Ordnerliste, Suchfeld, Neuer-Ordner-Bereich

### Tests (`tests/test_subfolders_api.py`)
- 18 neue Tests (GET: 6, POST: 12)
- Pfad-Traversal, Allowlist-Validierung, Idempotenz, Sortierung, Datei-Filterung

## Testergebnis
```
67 passed in 0.81s
```
(vorher: 49 Tests)

## Abhängigkeiten
- Baut auf Schritt 3 (PR #22, noch offen) auf
- PR #22 sollte vor oder gleichzeitig gemergt werden

Closes #12